### PR TITLE
Center labels vertically instead of static top-margin

### DIFF
--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -20,6 +20,7 @@ const PopupMenu = imports.ui.popupMenu;
 const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
+const Clutter = imports.gi.Clutter;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -79,7 +80,11 @@ const PropertyMenuItem = new Lang.Class({
                                       style_class: 'system-status-icon' });
 
     this._statisticLabelHidden = new St.Label({ text: '0' });
-    this._statisticLabelVisible = new St.Label({ text: '0', style_class: 'label' });
+    this._statisticLabelVisible = new St.Label({
+        text: '0',
+        style_class: 'label',
+        y_expand: true,
+        y_align: Clutter.ActorAlign.CENTER });
 
     this._box.add_child(this._icon);
     this._box.add_child(this._statisticLabelVisible);

--- a/src/nvidiautil@ethanwharris/stylesheet.css
+++ b/src/nvidiautil@ethanwharris/stylesheet.css
@@ -14,7 +14,6 @@ You should have received a copy of the GNU General Public License
 along with Nvidia Util Gnome Extension.  If not, see <http://www.gnu.org/licenses/>.*/
 
 .label {
-  margin-top: 3px;
   text-align: left;
 }
 


### PR DESCRIPTION
Took the liberty to put together a PR right away since quite small. And I did the code to confirm my suspicions. Looked at other gnome-shell-extensions for inspiration on how to solve it. (Freon specifically)

Removes the need to have a static top margin, and makes sure the labels are centered on all setups.

closes #161 