### PR TITLE
Correct usage of toString on Uint8Array

### DIFF
--- a/src/nvidiautil@ethanwharris/spawn.js
+++ b/src/nvidiautil@ethanwharris/spawn.js
@@ -29,7 +29,12 @@ function spawnAsync(command, callback) {
 
 function spawnSync(command, callback) {
   try {
-    return GLib.spawn_command_line_sync(command)[1].toString();
+    let data = GLib.spawn_command_line_sync(command)[1];
+    if (data instanceof Uint8Array) {
+      return imports.byteArray.toString(data);
+    } else {
+      return data.toString();
+    }
   } catch (err) {
     callback(command, err);
     return ERROR;


### PR DESCRIPTION
According to warning when using Gnome 3.30:
"Some code called array.toString() on a Uint8Array instance. Previously this would have interpreted the bytes of the array as a string, but that is nonstandard. In the future this will return the bytes as comma-separated digits. For the time being, the old behavior has been preserved, but please fix your code anyway to explicitly call ByteArray.toString(array)."

closes #165
