### PR TITLE
Update to ES6 style classes for compatibility with Gnome Shell 3.32

### DIFF
--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -21,6 +21,7 @@ const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Gtk = imports.gi.Gtk;
 const Clutter = imports.gi.Clutter;
+const GObject = imports.gi.GObject;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -54,11 +55,9 @@ function openPreferences() {
   Spawn.spawnAsync("gnome-shell-extension-prefs " + Me.metadata['uuid'], Spawn.defaultErrorHandler);
 }
 
-const PropertyMenuItem = new Lang.Class({
-  Name: 'PropertyMenuItem',
-  Extends: PopupMenu.PopupBaseMenuItem,
-  _init: function(property, box, labelManager, settings, setting, index) {
-    this.parent();
+class PropertyMenuItem extends PopupMenu.PopupBaseMenuItem {
+  constructor(property, box, labelManager, settings, setting, index) {
+    super();
 
     this._destroyed = false;
 
@@ -94,21 +93,21 @@ const PropertyMenuItem = new Lang.Class({
     this.actor.add(this._statisticLabelHidden);
     this._visible = false;
     this._box.visible = false;
-  },
-  reloadBox: function(spacing, icons) {
+  }
+  reloadBox(spacing, icons) {
     if (!this._destroyed) {
       this._icon.visible = icons;
 
       this._statisticLabelVisible.set_style('margin-right: ' + spacing + 'px');
     }
-  },
-  destroy: function() {
+  }
+  destroy() {
     this._destroyed = true;
 
     this._box.destroy();
     this._statisticLabelHidden.destroy();
 
-    this.parent();
+    super.destroy();
     this.activate = function(event) {
       // Do Nothing
     };
@@ -118,8 +117,8 @@ const PropertyMenuItem = new Lang.Class({
     this.setActive = function(active) {
       // Do Nothing
     }
-  },
-  activate: function(event) {
+  }
+  activate(event) {
     if (this._visible) {
       this.actor.remove_style_pseudo_class('active');
       this._visible = false;
@@ -139,14 +138,14 @@ const PropertyMenuItem = new Lang.Class({
       flags[this._index] = "active";
       this._settings.set_strv(this._setting, flags);
     }
-  },
-  setActive: function(active) {
-    this.parent(active);
+  }
+  setActive(active) {
+    super._init(active);
     if (this._visible) {
       this.actor.add_style_pseudo_class('active');
     }
-  },
-  handle: function(value) {
+  }
+  handle(value) {
     this._statisticLabelHidden.text = value;
     this._statisticLabelVisible.text = value;
     if (value == 'ERR') {
@@ -157,57 +156,52 @@ const PropertyMenuItem = new Lang.Class({
       this.destroy();
     }
   }
-});
+}
 
-const PersistentPopupMenu = new Lang.Class({
-  Name: 'PersistentPopupMenu',
-  Extends: PopupMenu.PopupMenu,
-  _init: function(actor, menuAlignment) {
-    this.parent(actor, menuAlignment, St.Side.TOP, 0);
-  },
-  _setOpenedSubMenu: function(submenu) {
+ class PersistentPopupMenu extends PopupMenu.PopupMenu {
+  constructor(actor, menuAlignment) {
+    super(actor, menuAlignment, St.Side.TOP, 0);
+  }
+  _setOpenedSubMenu(submenu) {
     this._openedSubMenu = submenu;
   }
-});
+}
 
-const GpuLabelDisplayManager = new Lang.Class({
-  Name: 'GpuLabelDisplayManager',
-  _init: function(gpuLabel) {
+ class GpuLabelDisplayManager {
+  constructor(gpuLabel) {
     this.gpuLabel = gpuLabel;
     this.count = 0;
     this.gpuLabel.visible = false;
-  },
-  increment: function() {
+  }
+  increment() {
     this.count = this.count + 1;
 
     if (this.gpuLabel.visible == false) {
       this.gpuLabel.visible = true;
     }
-  },
-  decrement: function() {
+  }
+  decrement() {
     this.count = this.count - 1;
 
     if (this.count == 0 && this.gpuLabel.visible == true) {
       this.gpuLabel.visible = false;
     }
   }
-});
+}
 
-const EmptyDisplayManager = new Lang.Class({
-  Name: 'EmptyDisplayManager',
-  increment: function() {
-    // Do Nothing
-  },
-  decrement: function() {
+ class EmptyDisplayManager {
+  increment() {
     // Do Nothing
   }
-});
+  decrement() {
+    // Do Nothing
+  }
+}
 
-const MainMenu = new Lang.Class({
-  Name: 'MainMenu',
-  Extends: PanelMenu.Button,
-  _init: function(settings) {
-    this.parent(0.0, _("GPU Statistics"));
+const MainMenu = GObject.registerClass(
+ class MainMenu extends PanelMenu.Button {
+  _init(settings) {
+    super._init(0.0, _("GPU Statistics"));
     this.timeoutId = -1;
     this._settings = settings;
     this._error = false;
@@ -234,8 +228,8 @@ const MainMenu = new Lang.Class({
     this._addSettingChangedSignal(Util.SETTINGS_POSITION, Lang.bind(this, this._updatePanelPosition));
     this._addSettingChangedSignal(Util.SETTINGS_SPACING, Lang.bind(this, this._updateSpacing));
     this._addSettingChangedSignal(Util.SETTINGS_ICONS, Lang.bind(this, this._updateSpacing));
-  },
-  _reload: function() {
+  }
+  _reload() {
     this.menu.removeAll();
 
     this._propertiesMenu = new PopupMenu.PopupMenuSection();
@@ -357,13 +351,13 @@ const MainMenu = new Lang.Class({
     }
 
     this.menu.addMenuItem(item);
-  },
-  _updatePollTime: function() {
+  }
+  _updatePollTime() {
     if (!this._error) {
       this._addTimeout(this._settings.get_int(Util.SETTINGS_REFRESH));
     }
-  },
-  _updateTempUnits: function() {
+  }
+  _updateTempUnits() {
     let unit = 0;
 
     for (let i = 0; i < this.providerProperties.length; i++) {
@@ -374,8 +368,8 @@ const MainMenu = new Lang.Class({
       }
     }
     this.processor.process();
-  },
-  _updatePanelPosition: function() {
+  }
+  _updatePanelPosition() {
     this.container.get_parent().remove_actor(this.container);
 
     let boxes = {
@@ -386,12 +380,12 @@ const MainMenu = new Lang.Class({
 
     let pos = this.getPanelPosition();
     boxes[pos].insert_child_at_index(this.container, pos == 'right' ? 0 : -1)
-  },
-  getPanelPosition : function() {
+  }
+  getPanelPosition() {
     let positions = ["left", "center", "right"];
     return positions[_settings.get_int(Util.SETTINGS_POSITION)];
-  },
-  _updateSpacing : function() {
+  }
+  _updateSpacing() {
     let spacing = _settings.get_int(Util.SETTINGS_SPACING);
     let icons = _settings.get_boolean(Util.SETTINGS_ICONS);
 
@@ -400,38 +394,38 @@ const MainMenu = new Lang.Class({
         this._items[i][n].reloadBox(spacing, icons);
       }
     }
-  },
+  }
   /*
    * Create and add the timeout which updates values every t seconds
    */
-  _addTimeout: function(t) {
+  _addTimeout(t) {
     this._removeTimeout();
 
     this.timeoutId = GLib.timeout_add_seconds(0, t, Lang.bind(this, function() {
       this.processor.process();
       return true;
     }));
-  },
+  }
   /*
    * Remove current timeout
    */
-  _removeTimeout: function() {
+  _removeTimeout() {
     if (this.timeoutId != -1) {
       GLib.source_remove(this.timeoutId);
       this.timeoutId = -1;
     }
-  },
-  _addSettingChangedSignal: function(key, callback) {
+  }
+  _addSettingChangedSignal(key, callback) {
     this._settingChangedSignals.push(this._settings.connect('changed::' + key, callback));
-  },
-  destroy: function() {
+  }
+  destroy() {
     this._removeTimeout();
 
     for (let signal of this._settingChangedSignals) {
       this._settings.disconnect(signal);
     };
 
-    this.parent();
+    super.destroy();
   }
 });
 

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -140,7 +140,7 @@ class PropertyMenuItem extends PopupMenu.PopupBaseMenuItem {
     }
   }
   setActive(active) {
-    super._init(active);
+    super.setActive(active);
     if (this._visible) {
       this.actor.add_style_pseudo_class('active');
     }

--- a/src/nvidiautil@ethanwharris/formatter.js
+++ b/src/nvidiautil@ethanwharris/formatter.js
@@ -13,18 +13,18 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with Nvidia Util Gnome Extension.  If not, see <http://www.gnu.org/licenses/>.*/
 
+const GObject = imports.gi.GObject;
 const Lang = imports.lang;
 
 var CENTIGRADE = 0;
 var FAHRENHEIT = 1;
 
-var Formatter = new Lang.Class({
-  Name: 'Formatter',
-  Abstract: true,
-  _init: function(name) {
+class Formatter {
+  //Abstract: true,
+  constructor(name) {
     this._name = name;
-  },
-  format: function(values) {
+  }
+  format(values) {
     for (let i = 0; i < values.length; i++) {
       let stringValue = values[i].replace(/[^0-9.]/g,'');
       values[i] = parseFloat(stringValue);
@@ -33,68 +33,60 @@ var Formatter = new Lang.Class({
       }
     }
     return this._format(values);
-  },
-  _format: function(values) {
+  }
+  _format(values) {
     return values;
   }
-});
+}
 
-var PercentFormatter = new Lang.Class({
-  Name: 'PercentFormatter',
-  Extends: Formatter,
-  _init: function(name) {
-    this.parent(name);
-  },
-  _format: function(values) {
+class PercentFormatter extends Formatter {
+  constructor(name) {
+    super(name);
+  }
+  _format(values) {
     return values[0] + "%";
   }
-})
+}
 
-var PowerFormatter = new Lang.Class({
-  Name: 'PowerFormatter',
-  Extends: Formatter,
-  _init: function() {
-    this.parent('PowerFormatter');
-  },
-  _format: function(values) {
+class PowerFormatter extends Formatter {
+  constructor() {
+    super('PowerFormatter');
+  }
+  _format(values) {
     return Math.floor(values[0]) + "W";
   }
-})
+}
 
-var MemoryFormatter = new Lang.Class({
-  Name: 'MemoryFormatter',
-  Extends: Formatter,
-  _init: function() {
-    this.parent('MemoryFormatter');
-  },
-  _format: function(values) {
+class MemoryFormatter extends Formatter {
+  constructor() {
+    super('MemoryFormatter');
+  }
+  _format(values) {
     let mem_usage = Math.floor((values[0] / values[1]) * 100);
     return mem_usage + "%";
   }
-})
+}
 
-var TempFormatter = new Lang.Class({
-  Name: 'TempFormatter',
-  Extends: Formatter,
-  currentUnit: 0,
-  _init: function(unit) {
-    this.parent('TempFormatter')
+class TempFormatter extends Formatter {
+  //currentUnit: 0,
+  constructor(unit) {
+    super('TempFormatter')
     this.currentUnit = unit;
-  },
-  setUnit: function(unit) {
+  }
+  setUnit(unit) {
     this.currentUnit = unit;
-  },
-  _format: function(value) {
+  }
+  _format(value) {
     if (this.currentUnit == CENTIGRADE) {
       return this._formatCentigrade(value);
     } else if (this.currentUnit == FAHRENHEIT) {
       return this._formatFehrenheit(value);
     }
-  },
-  _formatCentigrade: function(value) {
+  }
+  _formatCentigrade(value) {
     return value + "\xB0" + "C";
-  },
-  _formatFehrenheit: function(value) {
+  }
+  _formatFehrenheit(value) {
     return Math.floor(value*9/5+32) + "\xB0" + "F";
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/metadata.json
+++ b/src/nvidiautil@ethanwharris/metadata.json
@@ -2,19 +2,7 @@
   "description":
     "Shows NVIDIA GPU stats in the toolbar. Requires nvidia-settings or nvidia-smi. Includes Bumblebee support.",
   "shell-version": [
-    "3.6",
-    "3.8",
-    "3.10",
-    "3.12",
-    "3.14",
-    "3.16",
-    "3.18",
-    "3.20",
-    "3.22",
-    "3.24",
-    "3.26",
-    "3.28",
-    "3.30"
+    "3.32"
   ],
   "name": "NVIDIA GPU Stats Tool",
   "settings-schema": "org.gnome.shell.extensions.nvidiautil",

--- a/src/nvidiautil@ethanwharris/optimusProvider.js
+++ b/src/nvidiautil@ethanwharris/optimusProvider.js
@@ -22,11 +22,10 @@ const Spawn = Me.imports.spawn;
 const Processor = Me.imports.processor;
 const SmiProperties = Me.imports.smiProperties;
 
-var OptimusProvider = new Lang.Class({
-  Name: 'OptimusProvider',
-  _init: function() {
-  },
-  getGpuNames: function() {
+class OptimusProvider {
+  constructor() {
+  }
+  getGpuNames() {
     let output = Spawn.spawnSync("optirun nvidia-smi --query-gpu=gpu_name --format=csv,noheader", function(command, err) {
       // Do Nothing
     });
@@ -46,8 +45,8 @@ var OptimusProvider = new Lang.Class({
     }
 
     return output;
-  },
-  getProperties: function(gpuCount) {
+  }
+  getProperties(gpuCount) {
     this.storedProperties = [
       new SmiProperties.UtilisationProperty(gpuCount, Processor.OPTIMUS),
       new SmiProperties.TemperatureProperty(gpuCount, Processor.OPTIMUS),
@@ -56,14 +55,14 @@ var OptimusProvider = new Lang.Class({
       new SmiProperties.PowerProperty(gpuCount, Processor.OPTIMUS)
     ];
     return this.storedProperties;
-  },
-  retrieveProperties: function() {
+  }
+  retrieveProperties() {
     return this.storedProperties;
-  },
-  hasSettings: function() {
+  }
+  hasSettings() {
     return true;
-  },
-  openSettings: function() {
+  }
+  openSettings() {
     let defaultAppSystem = Shell.AppSystem.get_default();
     let nvidiaSettingsApp = defaultAppSystem.lookup_app('nvidia-settings.desktop');
 
@@ -78,4 +77,4 @@ var OptimusProvider = new Lang.Class({
       Spawn.spawnAsync('optirun -b none nvidia-settings -c :8', Spawn.defaultErrorHandler);
     }
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/processor.js
+++ b/src/nvidiautil@ethanwharris/processor.js
@@ -32,10 +32,10 @@ function andThen(first, second) {
   };
 }
 
-const Processor = new Lang.Class({
-  Name: 'Processor',
-  Abstract: true,
-  _init: function(name, baseCall, tailCall) {
+/* const class */
+class Processor {
+  //Abstract: true,
+  constructor(name, baseCall, tailCall) {
     this._name = name;
     this._baseCall = baseCall;
     this._tailCall = tailCall;
@@ -44,43 +44,39 @@ const Processor = new Lang.Class({
     this._parseFunction = function(lines) {
       return;
     };
-  },
-  parse: function(output) {
+  }
+  parse(output) {
     // Do Nothing
-  },
-  process: function() {
+  }
+  process() {
     var output = Spawn.spawnSync(this._call + this._tailCall, Spawn.defaultErrorHandler);
     if (output != Spawn.ERROR) {
       this.parse(output);
     }
-  },
-  addProperty: function(parseFunction, callExtension) {
+  }
+  addProperty(parseFunction, callExtension) {
     this._call += callExtension;
     this._parseFunction = andThen(this._parseFunction, parseFunction);
-  },
-  getName: function() {
+  }
+  getName() {
     return this._name;
   }
-});
+}
 
-var NvidiaSettingsProcessor = new Lang.Class({
-  Name: 'NvidiaSettingsProcessor',
-  Extends: Processor,
-  _init: function() {
-    this.parent('nvidia-settings', 'nvidia-settings ', '-t');
-  },
-  parse: function(output) {
+class NvidiaSettingsProcessor extends Processor {
+  constructor() {
+    super('nvidia-settings', 'nvidia-settings ', '-t');
+  }
+  parse(output) {
     this._parseFunction(output.split('\n'));
   }
-});
+}
 
-var OptimusSettingsProcessor = new Lang.Class({
-  Name: 'OptimusSettingsProcessor',
-  Extends: Processor,
-  _init: function() {
-    this.parent('optirun nvidia-smi', 'optirun nvidia-smi --query-gpu=', ' --format=csv,noheader,nounits');
-  },
-  parse: function(output) {
+class OptimusSettingsProcessor extends Processor {
+  constructor() {
+    super('optirun nvidia-smi', 'optirun nvidia-smi --query-gpu=', ' --format=csv,noheader,nounits');
+  }
+  parse(output) {
     let lines = output.split('\n');
     let items = [];
 
@@ -93,15 +89,13 @@ var OptimusSettingsProcessor = new Lang.Class({
 
     this._parseFunction(items);
   }
-});
+}
 
-var NvidiaSmiProcessor = new Lang.Class({
-  Name: 'NvidiaSmiProcessor',
-  Extends: Processor,
-  _init: function() {
-    this.parent('nvidia-smi', 'nvidia-smi --query-gpu=', ' --format=csv,noheader,nounits');
-  },
-  parse: function(output) {
+class NvidiaSmiProcessor extends Processor {
+  constructor() {
+    super('nvidia-smi', 'nvidia-smi --query-gpu=', ' --format=csv,noheader,nounits');
+  }
+  parse(output) {
     let lines = output.split('\n');
     let items = [];
 
@@ -114,7 +108,7 @@ var NvidiaSmiProcessor = new Lang.Class({
 
     this._parseFunction(items);
   }
-});
+}
 
 var LIST = [
   NvidiaSettingsProcessor,

--- a/src/nvidiautil@ethanwharris/processorHandler.js
+++ b/src/nvidiautil@ethanwharris/processorHandler.js
@@ -19,12 +19,11 @@ const Me = ExtensionUtils.getCurrentExtension();
 const Processor = Me.imports.processor;
 const Lang = imports.lang;
 
-var ProcessorHandler = new Lang.Class({
-  Name: 'ProcessorHandler',
-  _init: function() {
+class ProcessorHandler {
+  constructor() {
     this._processors = [false, false, false];
-  },
-  process: function() {
+  }
+  process() {
     for (let i = 0; i < this._processors.length; i++) {
       if (this._processors[i]) {
         try {
@@ -35,8 +34,8 @@ var ProcessorHandler = new Lang.Class({
         }
       }
     }
-  },
-  addProperty: function(property, listeners) {
+  }
+  addProperty(property, listeners) {
     let processor = property.declare();
     if (!this._processors[processor]) {
       this._processors[processor] = new Processor.LIST[processor]();
@@ -45,11 +44,12 @@ var ProcessorHandler = new Lang.Class({
     this._processors[processor].addProperty(function(lines) {
       let values = property.parse(lines);
       for(let i = 0; i < values.length; i++) {
-        listeners[i].handle(values[i]);
+        if (listeners[i])
+          listeners[i].handle(values[i]);
       }
     }, property.getCallExtension());
-  },
-  reset: function() {
+  }
+  reset() {
     this._processors = [false, false, false];
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/processorHandler.js
+++ b/src/nvidiautil@ethanwharris/processorHandler.js
@@ -44,7 +44,6 @@ class ProcessorHandler {
     this._processors[processor].addProperty(function(lines) {
       let values = property.parse(lines);
       for(let i = 0; i < values.length; i++) {
-        if (listeners[i])
           listeners[i].handle(values[i]);
       }
     }, property.getCallExtension());

--- a/src/nvidiautil@ethanwharris/property.js
+++ b/src/nvidiautil@ethanwharris/property.js
@@ -15,27 +15,26 @@ along with Nvidia Util Gnome Extension.  If not, see <http://www.gnu.org/license
 
 const Lang = imports.lang;
 
-var Property = new Lang.Class({
-  Name: 'Property',
-  Abstract: true,
-  _init: function(processor, name, callExtension, icon, formatter, gpuCount) {
+class Property {
+  //Abstract: true,
+  constructor(processor, name, callExtension, icon, formatter, gpuCount) {
     this._processor = processor;
     this._name = name;
     this._callExtension = callExtension;
     this._icon = icon;
     this._formatter = formatter;
     this._gpuCount = gpuCount;
-  },
-  getName: function() {
+  }
+  getName() {
     return this._name;
-  },
-  getCallExtension: function() {
+  }
+  getCallExtension() {
     return this._callExtension;
-  },
-  getIcon: function() {
+  }
+  getIcon() {
     return this._icon;
-  },
-  parse: function(lines) {
+  }
+  parse(lines) {
     let values = [];
 
     for (let i = 0; i < this._gpuCount; i++) {
@@ -43,8 +42,8 @@ var Property = new Lang.Class({
     }
 
     return values;
-  },
-  declare: function() {
+  }
+  declare() {
     return this._processor;
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
@@ -25,16 +25,15 @@ const Processor = Me.imports.processor;
 const SettingsProvider = Me.imports.settingsProvider;
 const SmiProvider = Me.imports.smiProvider;
 
-var SettingsAndSmiProvider = new Lang.Class({
-  Name: 'SettingsAndSmiProvider',
-  _init: function() {
+class SettingsAndSmiProvider {
+  constructor() {
     this.settings = new SettingsProvider.SettingsProvider();
     this.smi = new SmiProvider.SmiProvider();
-  },
-  getGpuNames: function() {
+  }
+  getGpuNames() {
     return this.smi.getGpuNames();
-  },
-  getProperties: function(gpuCount) {
+  }
+  getProperties(gpuCount) {
     this.storedProperties =  [
       new SettingsProperties.UtilisationProperty(gpuCount, Processor.NVIDIA_SETTINGS),
       new SettingsProperties.TemperatureProperty(gpuCount, Processor.NVIDIA_SETTINGS),
@@ -43,14 +42,14 @@ var SettingsAndSmiProvider = new Lang.Class({
       new SmiProperties.PowerProperty(gpuCount, Processor.NVIDIA_SMI)
     ];
     return this.storedProperties;
-  },
-  retrieveProperties: function() {
+  }
+  retrieveProperties() {
     return this.storedProperties;
-  },
-  hasSettings: function() {
+  }
+  hasSettings() {
     return true;
-  },
-  openSettings: function() {
+  }
+  openSettings() {
     this.settings.openSettings();
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/settingsProperties.js
+++ b/src/nvidiautil@ethanwharris/settingsProperties.js
@@ -19,39 +19,34 @@ const Lang = imports.lang;
 const Formatter = Me.imports.formatter;
 const Property = Me.imports.property;
 
-var UtilisationProperty = new Lang.Class({
-  Name: 'UtilisationProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Utilisation', '-q GPUUtilization ', 'card-symbolic', new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
-  },
-  parse: function(lines) {
+class UtilisationProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Utilisation', '-q GPUUtilization ', 'card-symbolic', new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
+  }
+  parse(lines) {
     for (let i = 0; i < this._gpuCount; i++) {
       lines[i] = lines[i].substring(9,11);
     }
 
-    return this.parent(lines);
+    //return super(lines); //super
+    return lines;
   }
-});
+}
 
-var TemperatureProperty = new Lang.Class({
-  Name: 'TemperatureProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Temperature', '-q [GPU]/GPUCoreTemp ', 'temp-symbolic', new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
-  },
-  setUnit: function(unit) {
+class TemperatureProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Temperature', '-q [GPU]/GPUCoreTemp ', 'temp-symbolic', new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
+  }
+  setUnit(unit) {
     this._formatter.setUnit(unit);
   }
-});
+}
 
-var MemoryProperty = new Lang.Class({
-  Name: 'MemoryProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Memory Usage', '-q UsedDedicatedGPUMemory -q TotalDedicatedGPUMemory ', 'ram-symbolic', new Formatter.MemoryFormatter(), gpuCount);
-  },
-  parse: function(lines) {
+class MemoryProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Memory Usage', '-q UsedDedicatedGPUMemory -q TotalDedicatedGPUMemory ', 'ram-symbolic', new Formatter.MemoryFormatter(), gpuCount);
+  }
+  parse(lines) {
     let values = [];
 
     let used_memory = [];
@@ -68,12 +63,10 @@ var MemoryProperty = new Lang.Class({
 
     return values;
   }
-});
+}
 
-var FanProperty = new Lang.Class({
-  Name: 'FanProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', 'fan-symbolic', new Formatter.PercentFormatter('FanFormatter'), gpuCount);
+class FanProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', 'fan-symbolic', new Formatter.PercentFormatter('FanFormatter'), gpuCount);
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/settingsProperties.js
+++ b/src/nvidiautil@ethanwharris/settingsProperties.js
@@ -28,8 +28,7 @@ class UtilisationProperty extends Property.Property {
       lines[i] = lines[i].substring(9,11);
     }
 
-    //return super(lines); //super
-    return lines;
+    return super.parse(lines);
   }
 }
 

--- a/src/nvidiautil@ethanwharris/settingsProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsProvider.js
@@ -22,11 +22,10 @@ const Spawn = Me.imports.spawn;
 const Processor = Me.imports.processor;
 const SettingsProperties = Me.imports.settingsProperties;
 
-var SettingsProvider = new Lang.Class({
-  Name: 'SettingsProvider',
-  _init: function() {
-  },
-  getGpuNames: function() {
+class SettingsProvider {
+  constructor() {
+  }
+  getGpuNames() {
     let output = Spawn.spawnSync("nvidia-settings -q GpuUUID -t", function(command, err) {
       // Do Nothing
     });
@@ -43,8 +42,8 @@ var SettingsProvider = new Lang.Class({
     }
 
     return result;
-  },
-  getProperties: function(gpuCount) {
+  }
+  getProperties(gpuCount) {
     this.storedProperties = [
       new SettingsProperties.UtilisationProperty(gpuCount, Processor.NVIDIA_SETTINGS),
       new SettingsProperties.TemperatureProperty(gpuCount, Processor.NVIDIA_SETTINGS),
@@ -52,14 +51,14 @@ var SettingsProvider = new Lang.Class({
       new SettingsProperties.FanProperty(gpuCount, Processor.NVIDIA_SETTINGS)
     ];
     return this.storedProperties;
-  },
-  retrieveProperties: function() {
+  }
+  retrieveProperties() {
     return this.storedProperties;
-  },
-  hasSettings: function() {
+  }
+  hasSettings() {
     return true;
-  },
-  openSettings: function() {
+  }
+  openSettings() {
     let defaultAppSystem = Shell.AppSystem.get_default();
     let nvidiaSettingsApp = defaultAppSystem.lookup_app('nvidia-settings.desktop');
 
@@ -74,4 +73,4 @@ var SettingsProvider = new Lang.Class({
       Spawn.spawnAsync('nvidia-settings', Spawn.defaultErrorHandler);
     }
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/smiProperties.js
+++ b/src/nvidiautil@ethanwharris/smiProperties.js
@@ -19,40 +19,32 @@ const Lang = imports.lang;
 const Property = Me.imports.property;
 const Formatter = Me.imports.formatter;
 
-var UtilisationProperty = new Lang.Class({
-  Name: 'UtilisationProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Utilisation', 'utilization.gpu,', 'card-symbolic', new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
+class UtilisationProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Utilisation', 'utilization.gpu,', 'card-symbolic', new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
   }
-});
+}
 
-var PowerProperty = new Lang.Class({
-  Name: 'PowerProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Power Usage (W)', 'power.draw,', 'power-symbolic', new Formatter.PowerFormatter(), gpuCount);
+class PowerProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Power Usage (W)', 'power.draw,', 'power-symbolic', new Formatter.PowerFormatter(), gpuCount);
   }
-});
+}
 
-var TemperatureProperty = new Lang.Class({
-  Name: 'TemperatureProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Temperature', 'temperature.gpu,', 'temp-symbolic', new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
-  },
-  setUnit: function(unit) {
+class TemperatureProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Temperature', 'temperature.gpu,', 'temp-symbolic', new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
+  }
+  setUnit(unit) {
     this._formatter.setUnit(unit);
   }
-});
+}
 
-var MemoryProperty = new Lang.Class({
-  Name: 'MemoryProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Memory Usage', 'memory.used,memory.total,', 'ram-symbolic', new Formatter.MemoryFormatter('MemoryFormatter'), gpuCount);
-  },
-  parse: function(lines) {
+class MemoryProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Memory Usage', 'memory.used,memory.total,', 'ram-symbolic', new Formatter.MemoryFormatter('MemoryFormatter'), gpuCount);
+  }
+  parse(lines) {
     let values = [];
 
     let used_memory = [];
@@ -69,12 +61,10 @@ var MemoryProperty = new Lang.Class({
 
     return values;
   }
-});
+}
 
-var FanProperty = new Lang.Class({
-  Name: 'FanProperty',
-  Extends: Property.Property,
-  _init: function(gpuCount, processor) {
-    this.parent(processor, 'Fan Speed', 'fan.speed,', 'fan-symbolic', new Formatter.PercentFormatter('FanFormatter'), gpuCount);
+class FanProperty extends Property.Property {
+  constructor(gpuCount, processor) {
+    super(processor, 'Fan Speed', 'fan.speed,', 'fan-symbolic', new Formatter.PercentFormatter('FanFormatter'), gpuCount);
   }
-});
+}

--- a/src/nvidiautil@ethanwharris/smiProvider.js
+++ b/src/nvidiautil@ethanwharris/smiProvider.js
@@ -21,11 +21,10 @@ const Spawn = Me.imports.spawn;
 const Processor = Me.imports.processor;
 const SmiProperties = Me.imports.smiProperties;
 
-var SmiProvider = new Lang.Class({
-  Name: 'SmiProvider',
-  _init: function() {
-  },
-  getGpuNames: function() {
+class SmiProvider {
+  constructor() {
+  }
+  getGpuNames() {
     let output = Spawn.spawnSync("nvidia-smi --query-gpu=gpu_name --format=csv,noheader", function(command, err) {
       // Do Nothing
     });
@@ -45,8 +44,8 @@ var SmiProvider = new Lang.Class({
     }
 
     return output;
-  },
-  getProperties: function(gpuCount) {
+  }
+  getProperties(gpuCount) {
     this.storedProperties = [
       new SmiProperties.UtilisationProperty(gpuCount, Processor.NVIDIA_SMI),
       new SmiProperties.TemperatureProperty(gpuCount, Processor.NVIDIA_SMI),
@@ -55,14 +54,14 @@ var SmiProvider = new Lang.Class({
       new SmiProperties.PowerProperty(gpuCount, Processor.NVIDIA_SMI)
     ];
     return this.storedProperties;
-  },
-  retrieveProperties: function() {
+  }
+  retrieveProperties() {
     return this.storedProperties;
-  },
-  hasSettings: function() {
+  }
+  hasSettings() {
     return false;
-  },
-  openSettings: function() {
+  }
+  openSettings() {
     Main.notifyError("Settings are not available in smi mode", "Switch to a provider which supports nivida-settings");
   }
-});
+}


### PR DESCRIPTION
The Gnome developers have made breaking changes to Gnome Shell Extensions as of gnome-shell v3.32.  This patch is essentially a conversion from `lang.class` style classes to ES6 style class syntax for solving issue #168.

note: this breaks backwards compatibility with older versions of Gnome Shell.  Also see:
https://gitlab.gnome.org/GNOME/gnome-shell/issues/1069
https://gitlab.gnome.org/GNOME/gnome-shell/issues/530#note_308621