### PR TITLE
Button cleanup

### DIFF
--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -74,7 +74,7 @@ class PropertyMenuItem extends PopupMenu.PopupBaseMenuItem {
     this.actor.add(new St.Icon({ style_class: 'popup-menu-icon', gicon: property.getIcon(), icon_size: 16 }));
 
     this.label = new St.Label({ text: property.getName() });
-    this.actor.add(this.label, { expand: true });
+    this.actor.add_child(this.label, { expand: true });
     this.actor.label_actor = this.label;
 
     this._icon = new St.Icon({ style_class: 'system-status-icon', gicon: property.getIcon(), icon_size: 16 });
@@ -366,7 +366,7 @@ var MainMenu = GObject.registerClass(
       }),
     });
     this.wrench.connect('clicked', () => { openPreferences(); });
-    item.add(this.wrench, { expand: true, x_fill: false });
+    item.add_child(this.wrench, { expand: true, x_fill: false });
 
     if (this.provider.hasSettings()) {
       this.cog = new St.Button({
@@ -381,7 +381,7 @@ var MainMenu = GObject.registerClass(
         }),
       });
       this.cog.connect('clicked', Lang.bind(this.provider, this.provider.openSettings));
-      item.actor.add(this.cog, { expand: true, x_fill: false });
+      item.actor.add_child(this.cog, { expand: true, x_fill: false });
     }
 
     this.menu.addMenuItem(item);

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -359,7 +359,7 @@ var MainMenu = GObject.registerClass(
       can_focus: true,
       track_hover: true,
       accessible_name: 'Open Preferences',
-      style_class: 'system-menu-action',
+      style_class: 'button',
       child: new St.Icon({
         icon_name: 'wrench-symbolic',
         gicon: GIcons.Wrench,
@@ -374,7 +374,7 @@ var MainMenu = GObject.registerClass(
         can_focus: true,
         track_hover: true,
         accessible_name: 'Open Nvidia Settings',
-        style_class: 'system-menu-action',
+        style_class: 'button',
         child: new St.Icon({
           icon_name: 'cog-symbolic',
           gicon: GIcons.Cog,

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -74,7 +74,7 @@ class PropertyMenuItem extends PopupMenu.PopupBaseMenuItem {
     this.actor.add(new St.Icon({ style_class: 'popup-menu-icon', gicon: property.getIcon(), icon_size: 16 }));
 
     this.label = new St.Label({ text: property.getName() });
-    this.actor.add_child(this.label, { expand: true });
+    this.actor.add_child(this.label);
     this.actor.label_actor = this.label;
 
     this._icon = new St.Icon({ style_class: 'system-status-icon', gicon: property.getIcon(), icon_size: 16 });
@@ -366,7 +366,7 @@ var MainMenu = GObject.registerClass(
       }),
     });
     this.wrench.connect('clicked', () => { openPreferences(); });
-    item.add_child(this.wrench, { expand: true, x_fill: false });
+    item.add_child(this.wrench);
 
     if (this.provider.hasSettings()) {
       this.cog = new St.Button({
@@ -381,7 +381,7 @@ var MainMenu = GObject.registerClass(
         }),
       });
       this.cog.connect('clicked', Lang.bind(this.provider, this.provider.openSettings));
-      item.actor.add_child(this.cog, { expand: true, x_fill: false });
+      item.actor.add_child(this.cog);
     }
 
     this.menu.addMenuItem(item);


### PR DESCRIPTION

![nvidia_extension_old](https://user-images.githubusercontent.com/35734401/95198307-eca9a700-07d2-11eb-801e-bc87a2fa9601.png)
![nvidia_extension](https://user-images.githubusercontent.com/35734401/95198191-b8ce8180-07d2-11eb-8911-6358e8715b11.png)
**Details**

error:
JS WARNING: [/home/**(username)**/.local/share/gnome-shell/extensions/nvidiautil@ethanwharris/extension.js 78]: Too many arguments to method Clutter.Actor.add_child: expected 1, got 2

fix:
updated to remove the invalid second parameters for the 'add_child' methods.


Also updated the button styles to look normal.

**Closing issues**

closes #177 & #178