### PR TITLE
fix 'Gtk.IconTheme.get_default() is null'

### DIFF
--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -468,7 +468,10 @@ let _settings;
  * Init function, nothing major here, do not edit view
  */
 function init() {
-  Gtk.IconTheme.get_default().append_search_path(Me.dir.get_child('icons').get_path());
+  let theme = new Gtk.IconTheme();
+  theme.set_custom_theme(St.Settings.get().gtk_icon_theme);
+  theme.append_search_path(Me.dir.get_child('icons').get_path());
+
   _settings = ExtensionUtils.getSettings();
 }
 


### PR DESCRIPTION
As already discussed, this mini-patch fixes the `Gtk.IconTheme.get_default() is null` error when using a Wayland session.

closes #183
