### PR TITLE
jsdoc linting and small improvements

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -3,9 +3,11 @@
 # SPDX-FileCopyrightText: 2018 Claudio André <claudioandre.br@gmail.com>
 env:
   es2021: true
-extends: 'eslint:recommended'
-#plugins:
-#  - jsdoc
+# extends: 'eslint:recommended'
+# Enable jsdoc and import their recommended settings (changed from original)
+plugins:
+  - jsdoc
+extends: ['eslint:recommended', 'plugin:jsdoc/recommended']
 rules:
   array-bracket-newline:
     - error
@@ -63,6 +65,7 @@ rules:
       - 'CallExpression[callee.object.name=GObject][callee.property.name=registerClass] > ClassExpression:first-child'
       # Allow dedenting chained member expressions
       MemberExpression: 'off'
+  # Original GJS jsdoc settings, disabled in favour of recommended settings
   # jsdoc/check-alignment: error
   # jsdoc/check-param-names: error
   # jsdoc/check-tag-names: error

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - run: npm install eslint -D
+      - run: npm install eslint eslint-plugin-jsdoc -D
       - uses: reviewdog/action-eslint@v1
         with:
           reporter: github-check

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -4,15 +4,10 @@
 /* exported init enable disable */
 'use strict';
 
-const St = imports.gi.St;
+const {Clutter, GLib, GObject, Gtk, St} = imports.gi;
 const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
-const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
-const Clutter = imports.gi.Clutter;
-const GObject = imports.gi.GObject;
-
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -427,9 +427,7 @@ var MainMenu = GObject.registerClass(
          }
      }
 
-     /*
-   * Create and add the timeout which updates values every t seconds
-   */
+     /* Create and add the timeout which updates values every t seconds */
      _addTimeout(t) {
          this._removeTimeout();
 
@@ -439,9 +437,7 @@ var MainMenu = GObject.registerClass(
          });
      }
 
-     /*
-   * Remove current timeout
-   */
+     /* Remove current timeout */
      _removeTimeout() {
          if (this.timeoutId !== -1) {
              GLib.source_remove(this.timeoutId);
@@ -467,7 +463,7 @@ var MainMenu = GObject.registerClass(
 let _menu;
 let _settings;
 
-/*
+/**
  * Init function, nothing major here, do not edit view
  */
 function init() {
@@ -478,6 +474,9 @@ function init() {
     _settings = ExtensionUtils.getSettings();
 }
 
+/**
+ * When the extension is enabled, add the menu to gnome panel
+ */
 function enable() {
     _menu = new MainMenu(_settings);
 
@@ -485,6 +484,9 @@ function enable() {
     Main.panel.addToStatusArea('main-menu', _menu, pos === 'right' ? 0 : -1, pos);
 }
 
+/**
+ * When the extension is disabled, remove the menu from gnome panel
+ */
 function disable() {
     _menu.destroy();
 }

--- a/src/nvidiautil@ethanwharris/formatter.js
+++ b/src/nvidiautil@ethanwharris/formatter.js
@@ -7,8 +7,7 @@
 var CENTIGRADE = 0;
 var FAHRENHEIT = 1;
 
-class Formatter {
-    // Abstract: true,
+class _Formatter {
     constructor(name) {
         this._name = name;
     }
@@ -28,18 +27,15 @@ class Formatter {
     }
 }
 
-var PercentFormatter = class extends Formatter {
+var PercentFormatter = class extends _Formatter {
     // implicitly use super constructor
-    // constructor(name) {
-    //     super(name);
-    // }
 
     _format(values) {
         return `${values[0]}%`;
     }
 };
 
-var PowerFormatter = class extends Formatter {
+var PowerFormatter = class extends _Formatter {
     constructor() {
         super('PowerFormatter');
     }
@@ -49,7 +45,7 @@ var PowerFormatter = class extends Formatter {
     }
 };
 
-var MemoryFormatter = class extends Formatter {
+var MemoryFormatter = class extends _Formatter {
     constructor() {
         super('MemoryFormatter');
     }
@@ -60,8 +56,7 @@ var MemoryFormatter = class extends Formatter {
     }
 };
 
-var TempFormatter = class extends Formatter {
-    // currentUnit: 0,
+var TempFormatter = class extends _Formatter {
     constructor(unit) {
         super('TempFormatter');
         this.currentUnit = unit;
@@ -73,16 +68,8 @@ var TempFormatter = class extends Formatter {
 
     _format(value) {
         if (this.currentUnit === CENTIGRADE)
-            return this._formatCentigrade(value);
+            return `${value}\xB0C`;
         else if (this.currentUnit === FAHRENHEIT)
-            return this._formatFahrenheit(value);
-    }
-
-    _formatCentigrade(value) {
-        return `${value}\xB0C`;
-    }
-
-    _formatFahrenheit(value) {
-        return `${Math.floor(value * 9 / 5 + 32)}\xB0F`;
+            return `${Math.floor(value * 9 / 5 + 32)}\xB0F`;
     }
 };

--- a/src/nvidiautil@ethanwharris/metadata.json
+++ b/src/nvidiautil@ethanwharris/metadata.json
@@ -2,7 +2,7 @@
   "description":
     "Shows NVIDIA GPU stats in the toolbar. Requires nvidia-settings or nvidia-smi. Includes Bumblebee support.",
   "shell-version": [
-    "40"
+    "40", "41"
   ],
   "name": "NVIDIA GPU Stats Tool",
   "settings-schema": "org.gnome.shell.extensions.nvidiautil",

--- a/src/nvidiautil@ethanwharris/optimusProvider.js
+++ b/src/nvidiautil@ethanwharris/optimusProvider.js
@@ -8,6 +8,7 @@ const Shell = imports.gi.Shell;
 const Main = imports.ui.main;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Processor = Me.imports.processor;
 const SmiProperties = Me.imports.smiProperties;
 const Subprocess = Me.imports.subprocess;

--- a/src/nvidiautil@ethanwharris/prefs.js
+++ b/src/nvidiautil@ethanwharris/prefs.js
@@ -56,15 +56,18 @@ const SETTINGS = {
 
 let settings;
 
-/*
+/**
  * Initialise this
  */
 function init() {
     settings = ExtensionUtils.getSettings();
 }
 
-/*
+/**
  * Construct the individual widget for an individual setting
+ *
+ * @param {string} setting Key from the SETTINGS dictionary
+ * @returns {object} GTK box for this single setting
  */
 function buildSettingWidget(setting) {
     if (SETTINGS[setting].type === 'noshow')
@@ -141,8 +144,10 @@ function buildSettingWidget(setting) {
     return box;
 }
 
-/*
+/**
  * Construct the entire widget for the settings dialog
+ *
+ * @returns {object} GTK box containing the entire settings dialog
  */
 function buildPrefsWidget() {
     let vbox = new Gtk.Box({orientation: Gtk.Orientation.VERTICAL, spacing: 10});

--- a/src/nvidiautil@ethanwharris/prefs.js
+++ b/src/nvidiautil@ethanwharris/prefs.js
@@ -4,9 +4,8 @@
 /* exported init buildPrefsWidget */
 'use strict';
 
-const Gtk = imports.gi.Gtk;
+const {GObject, Gtk} = imports.gi;
 const ExtensionUtils = imports.misc.extensionUtils;
-const GObject = imports.gi.GObject;
 
 const SETTINGS = {
     refreshrate: {

--- a/src/nvidiautil@ethanwharris/processor.js
+++ b/src/nvidiautil@ethanwharris/processor.js
@@ -7,6 +7,7 @@
 const Main = imports.ui.main;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Subprocess = Me.imports.subprocess;
 
 var NVIDIA_SETTINGS = 0;

--- a/src/nvidiautil@ethanwharris/processorHandler.js
+++ b/src/nvidiautil@ethanwharris/processorHandler.js
@@ -7,6 +7,7 @@
 const Main = imports.ui.main;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Processor = Me.imports.processor;
 
 var ProcessorHandler = class {

--- a/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
@@ -6,10 +6,10 @@
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const SettingsProperties = Me.imports.settingsProperties;
 const SmiProperties = Me.imports.smiProperties;
 const Processor = Me.imports.processor;
-
 const SettingsProvider = Me.imports.settingsProvider;
 const SmiProvider = Me.imports.smiProvider;
 

--- a/src/nvidiautil@ethanwharris/settingsProperties.js
+++ b/src/nvidiautil@ethanwharris/settingsProperties.js
@@ -6,6 +6,7 @@
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Formatter = Me.imports.formatter;
 const Property = Me.imports.property;
 const GIcons = Me.imports.gIcons;

--- a/src/nvidiautil@ethanwharris/settingsProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsProvider.js
@@ -8,6 +8,7 @@ const Shell = imports.gi.Shell;
 const Main = imports.ui.main;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Processor = Me.imports.processor;
 const SettingsProperties = Me.imports.settingsProperties;
 const Subprocess = Me.imports.subprocess;

--- a/src/nvidiautil@ethanwharris/smiProperties.js
+++ b/src/nvidiautil@ethanwharris/smiProperties.js
@@ -6,6 +6,7 @@
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Property = Me.imports.property;
 const Formatter = Me.imports.formatter;
 const GIcons = Me.imports.gIcons;

--- a/src/nvidiautil@ethanwharris/smiProvider.js
+++ b/src/nvidiautil@ethanwharris/smiProvider.js
@@ -7,6 +7,7 @@
 const Main = imports.ui.main;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
+
 const Processor = Me.imports.processor;
 const SmiProperties = Me.imports.smiProperties;
 const Subprocess = Me.imports.subprocess;

--- a/src/nvidiautil@ethanwharris/subprocess.js
+++ b/src/nvidiautil@ethanwharris/subprocess.js
@@ -31,10 +31,10 @@ async function execCheck(argv, cancellable = null) {
 
 
     return new Promise((resolve, reject) => {
-        proc.wait_check_async(null, (_proc, res) => {
+        proc.wait_check_async(null, (proc_, res) => {
             try {
-                if (!_proc.wait_check_finish(res)) {
-                    let status = _proc.get_exit_status();
+                if (!proc_.wait_check_finish(res)) {
+                    let status = proc_.get_exit_status();
 
                     throw new Gio.IOErrorEnum({
                         code: Gio.io_error_from_errno(status),
@@ -85,10 +85,10 @@ async function execCommunicate(argv, input = null, cancellable = null) {
 
 
     return new Promise((resolve, reject) => {
-        proc.communicate_utf8_async(input, null, (_proc, res) => {
+        proc.communicate_utf8_async(input, null, (proc_, res) => {
             try {
-                let [, stdout, stderr] = _proc.communicate_utf8_finish(res);
-                let status = _proc.get_exit_status();
+                let [, stdout, stderr] = proc_.communicate_utf8_finish(res);
+                let status = proc_.get_exit_status();
 
                 if (status !== 0) {
                     throw new Gio.IOErrorEnum({

--- a/src/nvidiautil@ethanwharris/subprocess.js
+++ b/src/nvidiautil@ethanwharris/subprocess.js
@@ -5,9 +5,7 @@
 /* eslint-disable require-await */
 'use strict';
 
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
-
+const {Gio, GLib} = imports.gi;
 
 /**
  * Execute a command asynchronously and check the exit status.


### PR DESCRIPTION
Last month, after our discussion in #190, I started looking into jsdoc by applying their _recommended_ eslint rules.
Then I went over the code to fix the jsdoc-related warnings and some minor coding style issues (mainly consistent naming for private classes, cleaner imports and a weird 1-space indentation in `extension.js`). After some weeks of testing on my own system, I think these changes are production ready.
On top, I've added a commit to flag the extension gnome-shell 41 compatible. I know it doesn't really belong to the cosmetic fixes, but it's so small it's not really worth a separate PR :smile: 

This is not yet the full set of commenting rules we imagined, but I already have an alternative eslint rule ready that should do the trick. It produces some (21) eslint warnings though, because I did not yet have the motivation to add all the documentation :grin: 