### PR TITLE
Fix version 9 review issues

### DIFF
--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -4,7 +4,7 @@
 /* exported init enable disable */
 'use strict';
 
-const {Clutter, GLib, GObject, Gtk, St} = imports.gi;
+const {Clutter, GLib, GObject, St} = imports.gi;
 const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -459,20 +459,10 @@ let _menu;
 let _settings;
 
 /**
- * Init function, nothing major here, do not edit view
- */
-function init() {
-    let theme = new Gtk.IconTheme();
-    theme.set_custom_theme(St.Settings.get().gtk_icon_theme);
-    theme.append_search_path(Me.dir.get_child('icons').get_path());
-
-    _settings = ExtensionUtils.getSettings();
-}
-
-/**
  * When the extension is enabled, add the menu to gnome panel
  */
 function enable() {
+    _settings = ExtensionUtils.getSettings();
     _menu = new MainMenu(_settings);
 
     let pos = _menu.getPanelPosition();
@@ -484,4 +474,6 @@ function enable() {
  */
 function disable() {
     _menu.destroy();
+    _menu = null;
+    _settings = null;
 }

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -349,8 +349,8 @@ class MainMenu extends PanelMenu.Button {
             accessible_name: 'Open Preferences',
             style_class: 'button',
             child: new St.Icon({
-                icon_name: 'wrench-symbolic',
-                gicon: GIcons.Wrench,
+                icon_name: GIcons.Icon.Wrench.name,
+                gicon: GIcons.Icon.Wrench.get(),
             }),
         });
         this.wrench.connect('clicked', () => {
@@ -366,8 +366,8 @@ class MainMenu extends PanelMenu.Button {
                 accessible_name: 'Open Nvidia Settings',
                 style_class: 'button',
                 child: new St.Icon({
-                    icon_name: 'cog-symbolic',
-                    gicon: GIcons.Cog,
+                    icon_name: GIcons.Icon.Cog.name,
+                    gicon: GIcons.Icon.Cog.get(),
                 }),
             });
             this.cog.connect('clicked', () => this.provider.openSettings());

--- a/src/nvidiautil@ethanwharris/gIcons.js
+++ b/src/nvidiautil@ethanwharris/gIcons.js
@@ -1,17 +1,27 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported Card Cog Fan Power RAM Temp Wrench */
+/* exported Icon */
 'use strict';
 
 const Gio = imports.gi.Gio;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
-var Card = Gio.icon_new_for_string(`${Me.path}/icons/card-symbolic.svg`);
-var Cog = Gio.icon_new_for_string(`${Me.path}/icons/cog-symbolic.svg`);
-var Fan = Gio.icon_new_for_string(`${Me.path}/icons/fan-symbolic.svg`);
-var Power = Gio.icon_new_for_string(`${Me.path}/icons/power-symbolic.svg`);
-var RAM = Gio.icon_new_for_string(`${Me.path}/icons/ram-symbolic.svg`);
-var Temp = Gio.icon_new_for_string(`${Me.path}/icons/temp-symbolic.svg`);
-var Wrench = Gio.icon_new_for_string(`${Me.path}/icons/wrench-symbolic.svg`);
+class Icon {
+    static Card = new Icon('card-symbolic');
+    static Temp = new Icon('temp-symbolic');
+    static RAM = new Icon('ram-symbolic');
+    static Fan = new Icon('fan-symbolic');
+    static Power = new Icon('power-symbolic');
+    static Wrench = new Icon('wrench-symbolic');
+    static Cog = new Icon('cog-symbolic');
+
+    constructor(name) {
+        this.name = name;
+    }
+
+    get() {
+        return Gio.icon_new_for_string(`${Me.path}/icons/${this.name}.svg`);
+    }
+}

--- a/src/nvidiautil@ethanwharris/gIcons.js
+++ b/src/nvidiautil@ethanwharris/gIcons.js
@@ -24,4 +24,4 @@ var Icon = class {
     get() {
         return Gio.icon_new_for_string(`${Me.path}/icons/${this.name}.svg`);
     }
-}
+};

--- a/src/nvidiautil@ethanwharris/gIcons.js
+++ b/src/nvidiautil@ethanwharris/gIcons.js
@@ -8,14 +8,14 @@ const Gio = imports.gi.Gio;
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 
-class Icon {
-    static Card = new Icon('card-symbolic');
-    static Temp = new Icon('temp-symbolic');
-    static RAM = new Icon('ram-symbolic');
-    static Fan = new Icon('fan-symbolic');
-    static Power = new Icon('power-symbolic');
-    static Wrench = new Icon('wrench-symbolic');
-    static Cog = new Icon('cog-symbolic');
+var Icon = class {
+    static Card = new this('card-symbolic');
+    static Temp = new this('temp-symbolic');
+    static RAM = new this('ram-symbolic');
+    static Fan = new this('fan-symbolic');
+    static Power = new this('power-symbolic');
+    static Wrench = new this('wrench-symbolic');
+    static Cog = new this('cog-symbolic');
 
     constructor(name) {
         this.name = name;

--- a/src/nvidiautil@ethanwharris/settingsProperties.js
+++ b/src/nvidiautil@ethanwharris/settingsProperties.js
@@ -13,7 +13,8 @@ const GIcons = Me.imports.gIcons;
 
 var UtilisationProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Utilisation', '-q GPUUtilization ', GIcons.Card, new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
+        super(processor, 'Utilisation', '-q GPUUtilization ', GIcons.Icon.Card.get(),
+            new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
     }
 
     parse(lines) {
@@ -27,7 +28,8 @@ var UtilisationProperty = class extends Property.Property {
 
 var TemperatureProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Temperature', '-q [GPU]/GPUCoreTemp ', GIcons.Temp, new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
+        super(processor, 'Temperature', '-q [GPU]/GPUCoreTemp ', GIcons.Icon.Temp.get(),
+            new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
     }
 
     setUnit(unit) {
@@ -37,12 +39,12 @@ var TemperatureProperty = class extends Property.Property {
 
 var MemoryProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Memory Usage', '-q UsedDedicatedGPUMemory -q TotalDedicatedGPUMemory ', GIcons.RAM, new Formatter.MemoryFormatter(), gpuCount);
+        super(processor, 'Memory Usage', '-q UsedDedicatedGPUMemory -q TotalDedicatedGPUMemory ', GIcons.Icon.RAM.get(),
+            new Formatter.MemoryFormatter(), gpuCount);
     }
 
     parse(lines) {
         let values = [];
-
         let used_memory = [];
 
         for (let i = 0; i < this._gpuCount; i++)
@@ -61,6 +63,7 @@ var MemoryProperty = class extends Property.Property {
 
 var FanProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', GIcons.Fan, new Formatter.PercentFormatter('FanFormatter'), gpuCount);
+        super(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', GIcons.Icon.Fan.get(),
+            new Formatter.PercentFormatter('FanFormatter'), gpuCount);
     }
 };

--- a/src/nvidiautil@ethanwharris/smiProperties.js
+++ b/src/nvidiautil@ethanwharris/smiProperties.js
@@ -13,19 +13,22 @@ const GIcons = Me.imports.gIcons;
 
 var UtilisationProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Utilisation', 'utilization.gpu,', GIcons.Card, new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
+        super(processor, 'Utilisation', 'utilization.gpu,', GIcons.Icon.Card.get(),
+            new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
     }
 };
 
 var PowerProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Power Usage (W)', 'power.draw,', GIcons.Power, new Formatter.PowerFormatter(), gpuCount);
+        super(processor, 'Power Usage (W)', 'power.draw,', GIcons.Icon.Power.get(),
+            new Formatter.PowerFormatter(), gpuCount);
     }
 };
 
 var TemperatureProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Temperature', 'temperature.gpu,', GIcons.Temp, new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
+        super(processor, 'Temperature', 'temperature.gpu,', GIcons.Icon.Temp.get(),
+            new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
     }
 
     setUnit(unit) {
@@ -35,12 +38,12 @@ var TemperatureProperty = class extends Property.Property {
 
 var MemoryProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Memory Usage', 'memory.used,memory.total,', GIcons.RAM, new Formatter.MemoryFormatter('MemoryFormatter'), gpuCount);
+        super(processor, 'Memory Usage', 'memory.used,memory.total,', GIcons.Icon.RAM.get(),
+            new Formatter.MemoryFormatter('MemoryFormatter'), gpuCount);
     }
 
     parse(lines) {
         let values = [];
-
         let used_memory = [];
 
         for (let i = 0; i < this._gpuCount; i++)
@@ -59,6 +62,7 @@ var MemoryProperty = class extends Property.Property {
 
 var FanProperty = class extends Property.Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Fan Speed', 'fan.speed,', GIcons.Fan, new Formatter.PercentFormatter('FanFormatter'), gpuCount);
+        super(processor, 'Fan Speed', 'fan.speed,', GIcons.Icon.Fan.get(),
+            new Formatter.PercentFormatter('FanFormatter'), gpuCount);
     }
 };


### PR DESCRIPTION
**Description**
The review revealed three issues, this PR aims to fix them.

1. Remove code from `init()`, move initialisation of `_settings` to `enable()`, null it in `disable()`.
2. Also, null `_menu` in `disable()`
3. Remove icons from global scope, create an enum-like class that creates them instead.

**Closing issues**
closes #199

*Note: it might be a good idea to also merge another small change and bump gnome-shell to version 42, as Ubuntu 22.04 will use gnome-shell 42.*