### PR TITLE
Update metadata.json for gnome 44

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -9,6 +9,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps: 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: REUSE Compliance Check
       uses: fsfe/reuse-action@v1

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -8,10 +8,10 @@ jobs:
     name: runner / eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '16'
       - run: npm install eslint eslint-plugin-jsdoc -D
       - uses: reviewdog/action-eslint@v1
         with:

--- a/src/nvidiautil@ethanwharris/metadata.json
+++ b/src/nvidiautil@ethanwharris/metadata.json
@@ -2,7 +2,7 @@
   "description":
     "Shows NVIDIA GPU stats in the toolbar. Requires nvidia-settings or nvidia-smi. Includes Bumblebee support.",
   "shell-version": [
-    "40", "41", "42", "43"
+    "40", "41", "42", "43", "44"
   ],
   "name": "NVIDIA GPU Stats Tool",
   "settings-schema": "org.gnome.shell.extensions.nvidiautil",


### PR DESCRIPTION
As always, this little version bump for `metadata.json` is required to make the extension work on the most recent gnome. I tested it on my machine (Manjaro with gnome 44), it works as expected.
As extension version 11 has not yet been released, there's no need to bump the version number as well.