### PR TITLE
Gnome 45 compatibility

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -270,4 +270,5 @@ globals:
   clearTimeout: readonly
   clearInterval: readonly
 parserOptions:
+  sourceType: module
   ecmaVersion: 2022

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 A Gnome extension to show Nvidia GPU information
 (https://extensions.gnome.org/extension/1320/nvidia-gpu-stats-tool/)
 
+# Supported Gnome versions
+The "master" branch supports only Gnome v45+.
+For older shell versions, please check out the "legacy" branch.
+
 # Requirements
 nvidia-settings and nvidia-smi
 

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -4,19 +4,33 @@
 /* exported init enable disable */
 'use strict';
 
-const {Clutter, GLib, GObject, St} = imports.gi;
-const Main = imports.ui.main;
-const PanelMenu = imports.ui.panelMenu;
-const PopupMenu = imports.ui.popupMenu;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+//const {Clutter, GLib, GObject, St} = imports.gi;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+//const Main = imports.ui.main;
+//const PanelMenu = imports.ui.panelMenu;
+//const PopupMenu = imports.ui.popupMenu;
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const ProcessorHandler = Me.imports.processorHandler;
-const SettingsProvider = Me.imports.settingsProvider;
-const SmiProvider = Me.imports.smiProvider;
-const SettingsAndSmiProvider = Me.imports.settingsAndSmiProvider;
-const OptimusProvider = Me.imports.optimusProvider;
-const GIcons = Me.imports.gIcons;
+import {ProcessorHandler} from './processorHandler.js';
+import {SettingsProvider} from './settingsProvider.js';
+import {SmiProvider} from './smiProvider.js';
+import {SettingsAndSmiProvider} from './settingsAndSmiProvider.js';
+import {OptimusProvider} from './optimusProvider.js';
+import * as GIcons from './gIcons.js';
+//const ProcessorHandler = Me.imports.processorHandler;
+//const SettingsProvider = Me.imports.settingsProvider;
+//const SmiProvider = Me.imports.smiProvider;
+//const SettingsAndSmiProvider = Me.imports.settingsAndSmiProvider;
+//const OptimusProvider = Me.imports.optimusProvider;
+//const GIcons = Me.imports.gIcons;
 
 const SETTINGS_REFRESH = 'refreshrate';
 const SETTINGS_PROVIDER = 'provider';
@@ -26,10 +40,10 @@ const SETTINGS_SPACING = 'spacing';
 const SETTINGS_ICONS = 'icons';
 
 const PROVIDERS = [
-    SettingsAndSmiProvider.SettingsAndSmiProvider,
-    SettingsProvider.SettingsProvider,
-    SmiProvider.SmiProvider,
-    OptimusProvider.OptimusProvider,
+    SettingsAndSmiProvider,
+    SettingsProvider,
+    SmiProvider,
+    OptimusProvider,
 ];
 
 const PROVIDER_SETTINGS = [
@@ -221,7 +235,7 @@ class MainMenu extends PanelMenu.Button {
         this._settings = settings;
         this._error = false;
 
-        this.processor = new ProcessorHandler.ProcessorHandler();
+        this.processor = new ProcessorHandler();
 
         this.setMenu(new _PersistentPopupMenu(this, 0.0));
 
@@ -354,7 +368,9 @@ class MainMenu extends PanelMenu.Button {
             }),
         });
         this.wrench.connect('clicked', () => {
-            ExtensionUtils.openPrefs();
+            let extensionObject = Extension.lookupByURL(import.meta.url);
+            extensionObject.openPreferences();
+            //ExtensionUtils.openPrefs();
         });
         item.add_child(this.wrench);
 
@@ -458,22 +474,24 @@ class MainMenu extends PanelMenu.Button {
 let _menu;
 let _settings;
 
-/**
- * When the extension is enabled, add the menu to gnome panel
- */
-function enable() {
-    _settings = ExtensionUtils.getSettings();
-    _menu = new MainMenu(_settings);
+export default class NvidiaUtil extends Extension {
+    /**
+     * When the extension is enabled, add the menu to gnome panel
+     */
+    enable() {
+        _settings = this.getSettings();
+        _menu = new MainMenu(_settings);
 
-    let pos = _menu.getPanelPosition();
-    Main.panel.addToStatusArea('main-menu', _menu, pos === 'right' ? 0 : -1, pos);
-}
+        let pos = _menu.getPanelPosition();
+        Main.panel.addToStatusArea('main-menu', _menu, pos === 'right' ? 0 : -1, pos);
+    }
 
-/**
- * When the extension is disabled, remove the menu from gnome panel
- */
-function disable() {
-    _menu.destroy();
-    _menu = null;
-    _settings = null;
+    /**
+     * When the extension is disabled, remove the menu from gnome panel
+     */
+    disable() {
+        _menu.destroy();
+        _menu = null;
+        _settings = null;
+    }
 }

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -1,23 +1,16 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported init enable disable */
 'use strict';
 
 import Clutter from 'gi://Clutter';
 import GLib from 'gi://GLib';
 import GObject from 'gi://GObject';
 import St from 'gi://St';
-//const {Clutter, GLib, GObject, St} = imports.gi;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
-//const Main = imports.ui.main;
-//const PanelMenu = imports.ui.panelMenu;
-//const PopupMenu = imports.ui.popupMenu;
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import {ProcessorHandler} from './processorHandler.js';
 import {SettingsProvider} from './settingsProvider.js';
@@ -25,12 +18,6 @@ import {SmiProvider} from './smiProvider.js';
 import {SettingsAndSmiProvider} from './settingsAndSmiProvider.js';
 import {OptimusProvider} from './optimusProvider.js';
 import * as GIcons from './gIcons.js';
-//const ProcessorHandler = Me.imports.processorHandler;
-//const SettingsProvider = Me.imports.settingsProvider;
-//const SmiProvider = Me.imports.smiProvider;
-//const SettingsAndSmiProvider = Me.imports.settingsAndSmiProvider;
-//const OptimusProvider = Me.imports.optimusProvider;
-//const GIcons = Me.imports.gIcons;
 
 const SETTINGS_REFRESH = 'refreshrate';
 const SETTINGS_PROVIDER = 'provider';
@@ -370,7 +357,6 @@ class MainMenu extends PanelMenu.Button {
         this.wrench.connect('clicked', () => {
             let extensionObject = Extension.lookupByURL(import.meta.url);
             extensionObject.openPreferences();
-            //ExtensionUtils.openPrefs();
         });
         item.add_child(this.wrench);
 

--- a/src/nvidiautil@ethanwharris/formatter.js
+++ b/src/nvidiautil@ethanwharris/formatter.js
@@ -4,8 +4,8 @@
 /* exported CENTIGRADE FAHRENHEIT PercentFormatter PowerFormatter MemoryFormatter TempFormatter */
 'use strict';
 
-var CENTIGRADE = 0;
-var FAHRENHEIT = 1;
+export const CENTIGRADE = 0;
+export const FAHRENHEIT = 1;
 
 class _Formatter {
     constructor(name) {
@@ -27,7 +27,7 @@ class _Formatter {
     }
 }
 
-var PercentFormatter = class extends _Formatter {
+export class PercentFormatter extends _Formatter {
     // implicitly use super constructor
 
     _format(values) {
@@ -35,7 +35,7 @@ var PercentFormatter = class extends _Formatter {
     }
 };
 
-var PowerFormatter = class extends _Formatter {
+export class PowerFormatter extends _Formatter {
     constructor() {
         super('PowerFormatter');
     }
@@ -45,7 +45,7 @@ var PowerFormatter = class extends _Formatter {
     }
 };
 
-var MemoryFormatter = class extends _Formatter {
+export class MemoryFormatter extends _Formatter {
     constructor() {
         super('MemoryFormatter');
     }
@@ -56,7 +56,7 @@ var MemoryFormatter = class extends _Formatter {
     }
 };
 
-var TempFormatter = class extends _Formatter {
+export class TempFormatter extends _Formatter {
     constructor(unit) {
         super('TempFormatter');
         this.currentUnit = unit;

--- a/src/nvidiautil@ethanwharris/formatter.js
+++ b/src/nvidiautil@ethanwharris/formatter.js
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported CENTIGRADE FAHRENHEIT PercentFormatter PowerFormatter MemoryFormatter TempFormatter */
 'use strict';
 
 export const CENTIGRADE = 0;
@@ -33,7 +32,7 @@ export class PercentFormatter extends _Formatter {
     _format(values) {
         return `${values[0]}%`;
     }
-};
+}
 
 export class PowerFormatter extends _Formatter {
     constructor() {
@@ -43,7 +42,7 @@ export class PowerFormatter extends _Formatter {
     _format(values) {
         return `${Math.floor(values[0])}W`;
     }
-};
+}
 
 export class MemoryFormatter extends _Formatter {
     constructor() {
@@ -54,7 +53,7 @@ export class MemoryFormatter extends _Formatter {
         let mem_usage = Math.floor((values[0] / values[1]) * 100);
         return `${mem_usage}%`;
     }
-};
+}
 
 export class TempFormatter extends _Formatter {
     constructor(unit) {
@@ -72,4 +71,4 @@ export class TempFormatter extends _Formatter {
         else if (this.currentUnit === FAHRENHEIT)
             return `${Math.floor(value * 9 / 5 + 32)}\xB0F`;
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/gIcons.js
+++ b/src/nvidiautil@ethanwharris/gIcons.js
@@ -4,11 +4,14 @@
 /* exported Icon */
 'use strict';
 
-const Gio = imports.gi.Gio;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Gio from 'gi://Gio';
+//const Gio = imports.gi.Gio;
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
-var Icon = class {
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
+
+export class Icon {
     static Card = new this('card-symbolic');
     static Temp = new this('temp-symbolic');
     static RAM = new this('ram-symbolic');
@@ -22,6 +25,7 @@ var Icon = class {
     }
 
     get() {
-        return Gio.icon_new_for_string(`${Me.path}/icons/${this.name}.svg`);
+        let extensionObject = Extension.lookupByURL(import.meta.url);
+        return Gio.icon_new_for_string(`${extensionObject.path}/icons/${this.name}.svg`);
     }
 };

--- a/src/nvidiautil@ethanwharris/gIcons.js
+++ b/src/nvidiautil@ethanwharris/gIcons.js
@@ -1,15 +1,10 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported Icon */
 'use strict';
 
 import Gio from 'gi://Gio';
-//const Gio = imports.gi.Gio;
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
-
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 export class Icon {
     static Card = new this('card-symbolic');
@@ -28,4 +23,4 @@ export class Icon {
         let extensionObject = Extension.lookupByURL(import.meta.url);
         return Gio.icon_new_for_string(`${extensionObject.path}/icons/${this.name}.svg`);
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/metadata.json
+++ b/src/nvidiautil@ethanwharris/metadata.json
@@ -2,7 +2,7 @@
   "description":
     "Shows NVIDIA GPU stats in the toolbar. Requires nvidia-settings or nvidia-smi. Includes Bumblebee support.",
   "shell-version": [
-    "40", "41", "42", "43", "44"
+    "45"
   ],
   "name": "NVIDIA GPU Stats Tool",
   "settings-schema": "org.gnome.shell.extensions.nvidiautil",

--- a/src/nvidiautil@ethanwharris/optimusProvider.js
+++ b/src/nvidiautil@ethanwharris/optimusProvider.js
@@ -1,22 +1,14 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported OptimusProvider */
 'use strict';
 
 import Shell from 'gi://Shell';
-//const Shell = imports.gi.Shell;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-//const Main = imports.ui.main;
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as Processor from './processor.js';
 import * as SmiProperties from './smiProperties.js';
 import * as Subprocess from './subprocess.js';
-//const Processor = Me.imports.processor;
-//const SmiProperties = Me.imports.smiProperties;
-//const Subprocess = Me.imports.subprocess;
 
 export class OptimusProvider {
     getGpuNames() {
@@ -61,4 +53,4 @@ export class OptimusProvider {
             });
         }
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/optimusProvider.js
+++ b/src/nvidiautil@ethanwharris/optimusProvider.js
@@ -4,16 +4,21 @@
 /* exported OptimusProvider */
 'use strict';
 
-const Shell = imports.gi.Shell;
-const Main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Shell from 'gi://Shell';
+//const Shell = imports.gi.Shell;
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+//const Main = imports.ui.main;
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const Processor = Me.imports.processor;
-const SmiProperties = Me.imports.smiProperties;
-const Subprocess = Me.imports.subprocess;
+import * as Processor from './processor.js';
+import * as SmiProperties from './smiProperties.js';
+import * as Subprocess from './subprocess.js';
+//const Processor = Me.imports.processor;
+//const SmiProperties = Me.imports.smiProperties;
+//const Subprocess = Me.imports.subprocess;
 
-var OptimusProvider = class {
+export class OptimusProvider {
     getGpuNames() {
         return Subprocess.execCommunicate(['optirun', 'nvidia-smi', '--query-gpu=gpu_name', '--format=csv,noheader'])
       .then(output => output.split('\n').map((gpu, index) => `${index}: ${gpu}`));

--- a/src/nvidiautil@ethanwharris/prefs.js
+++ b/src/nvidiautil@ethanwharris/prefs.js
@@ -4,8 +4,12 @@
 /* exported init buildPrefsWidget */
 'use strict';
 
-const {GObject, Gtk} = imports.gi;
-const ExtensionUtils = imports.misc.extensionUtils;
+import Adw from 'gi://Adw';
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+//const {GObject, Gtk} = imports.gi;
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+//const ExtensionUtils = imports.misc.extensionUtils;
 
 const SETTINGS = {
     refreshrate: {
@@ -58,8 +62,22 @@ let settings;
 /**
  * Initialise this
  */
-function init() {
-    settings = ExtensionUtils.getSettings();
+//function init() {
+//    let extensionObject = Extension.lookupByURL(import.meta.url);
+//    settings = extensionObject.getSettings();
+//}
+
+export default class NvidiaUtilPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        settings = this.getSettings();
+
+        const page = new Adw.PreferencesPage();
+        const group = new Adw.PreferencesGroup();
+
+        group.add(buildPrefsWidget());
+        page.add(group);
+        window.add(page);
+    }
 }
 
 /**

--- a/src/nvidiautil@ethanwharris/prefs.js
+++ b/src/nvidiautil@ethanwharris/prefs.js
@@ -1,15 +1,12 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported init buildPrefsWidget */
 'use strict';
 
 import Adw from 'gi://Adw';
 import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk';
-//const {GObject, Gtk} = imports.gi;
 import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
-//const ExtensionUtils = imports.misc.extensionUtils;
 
 const SETTINGS = {
     refreshrate: {
@@ -58,14 +55,6 @@ const SETTINGS = {
 };
 
 let settings;
-
-/**
- * Initialise this
- */
-//function init() {
-//    let extensionObject = Extension.lookupByURL(import.meta.url);
-//    settings = extensionObject.getSettings();
-//}
 
 export default class NvidiaUtilPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {

--- a/src/nvidiautil@ethanwharris/processor.js
+++ b/src/nvidiautil@ethanwharris/processor.js
@@ -12,9 +12,9 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Subprocess from './subprocess.js';
 //const Subprocess = Me.imports.subprocess;
 
-var NVIDIA_SETTINGS = 0;
-var NVIDIA_SMI = 1;
-var OPTIMUS = 2;
+export const NVIDIA_SETTINGS = 0;
+export const NVIDIA_SMI = 1;
+export const OPTIMUS = 2;
 
 /**
  * Utility function to perform one function and then another
@@ -94,7 +94,7 @@ class NvidiaSmiProcessor extends _Processor {
 }
 
 /* The public interface consists of this array and the constants for indexing */
-var LIST = [
+export const LIST = [
     NvidiaSettingsProcessor,
     NvidiaSmiProcessor,
     OptimusSettingsProcessor,

--- a/src/nvidiautil@ethanwharris/processor.js
+++ b/src/nvidiautil@ethanwharris/processor.js
@@ -4,11 +4,13 @@
 /* exported NVIDIA_SETTINGS NVIDIA_SMI OPTIMUS LIST */
 'use strict';
 
-const Main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+//const Main = imports.ui.main;
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const Subprocess = Me.imports.subprocess;
+import * as Subprocess from './subprocess.js';
+//const Subprocess = Me.imports.subprocess;
 
 var NVIDIA_SETTINGS = 0;
 var NVIDIA_SMI = 1;

--- a/src/nvidiautil@ethanwharris/processor.js
+++ b/src/nvidiautil@ethanwharris/processor.js
@@ -1,16 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported NVIDIA_SETTINGS NVIDIA_SMI OPTIMUS LIST */
 'use strict';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-//const Main = imports.ui.main;
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as Subprocess from './subprocess.js';
-//const Subprocess = Me.imports.subprocess;
 
 export const NVIDIA_SETTINGS = 0;
 export const NVIDIA_SMI = 1;

--- a/src/nvidiautil@ethanwharris/processorHandler.js
+++ b/src/nvidiautil@ethanwharris/processorHandler.js
@@ -1,16 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported ProcessorHandler */
 'use strict';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-//const Main = imports.ui.main;
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as Processor from './processor.js';
-//const Processor = Me.imports.processor;
 
 export class ProcessorHandler {
     constructor() {
@@ -46,4 +41,4 @@ export class ProcessorHandler {
     reset() {
         this._processors = [false, false, false];
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/processorHandler.js
+++ b/src/nvidiautil@ethanwharris/processorHandler.js
@@ -4,13 +4,15 @@
 /* exported ProcessorHandler */
 'use strict';
 
-const Main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+//const Main = imports.ui.main;
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const Processor = Me.imports.processor;
+import * as Processor from './processor.js';
+//const Processor = Me.imports.processor;
 
-var ProcessorHandler = class {
+export class ProcessorHandler {
     constructor() {
         this._processors = [false, false, false];
     }

--- a/src/nvidiautil@ethanwharris/property.js
+++ b/src/nvidiautil@ethanwharris/property.js
@@ -1,7 +1,6 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported Property */
 'use strict';
 
 export class Property {
@@ -40,4 +39,4 @@ export class Property {
     declare() {
         return this._processor;
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/property.js
+++ b/src/nvidiautil@ethanwharris/property.js
@@ -4,7 +4,7 @@
 /* exported Property */
 'use strict';
 
-var Property = class {
+export class Property {
     // Abstract: true,
     constructor(processor, name, callExtension, icon, formatter, gpuCount) {
         this._processor = processor;

--- a/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
@@ -4,16 +4,21 @@
 /* exported SettingsAndSmiProvider */
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const SettingsProperties = Me.imports.settingsProperties;
-const SmiProperties = Me.imports.smiProperties;
-const Processor = Me.imports.processor;
-const SettingsProvider = Me.imports.settingsProvider;
-const SmiProvider = Me.imports.smiProvider;
+import * as SettingsProperties from './settingsProperties.js';
+import * as SmiProperties from './smiProperties.js';
+import * as Processor from './processor.js';
+import * as SettingsProvider from './settingsProvider.js';
+import * as SmiProvider from './smiProvider.js';
+//const SettingsProperties = Me.imports.settingsProperties;
+//const SmiProperties = Me.imports.smiProperties;
+//const Processor = Me.imports.processor;
+//const SettingsProvider = Me.imports.settingsProvider;
+//const SmiProvider = Me.imports.smiProvider;
 
-var SettingsAndSmiProvider = class {
+export class SettingsAndSmiProvider {
     constructor() {
         this.settings = new SettingsProvider.SettingsProvider();
         this.smi = new SmiProvider.SmiProvider();

--- a/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
@@ -1,22 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported SettingsAndSmiProvider */
 'use strict';
-
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as SettingsProperties from './settingsProperties.js';
 import * as SmiProperties from './smiProperties.js';
 import * as Processor from './processor.js';
 import * as SettingsProvider from './settingsProvider.js';
 import * as SmiProvider from './smiProvider.js';
-//const SettingsProperties = Me.imports.settingsProperties;
-//const SmiProperties = Me.imports.smiProperties;
-//const Processor = Me.imports.processor;
-//const SettingsProvider = Me.imports.settingsProvider;
-//const SmiProvider = Me.imports.smiProvider;
 
 export class SettingsAndSmiProvider {
     constructor() {
@@ -50,4 +41,4 @@ export class SettingsAndSmiProvider {
     openSettings() {
         this.settings.openSettings();
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/settingsProperties.js
+++ b/src/nvidiautil@ethanwharris/settingsProperties.js
@@ -1,18 +1,11 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported UtilisationProperty TemperatureProperty MemoryProperty FanProperty */
 'use strict';
-
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as Formatter from './formatter.js';
 import {Property} from './property.js';
 import * as GIcons from './gIcons.js';
-//const Formatter = Me.imports.formatter;
-//const Property = Me.imports.property;
-//const GIcons = Me.imports.gIcons;
 
 export class UtilisationProperty extends Property {
     constructor(gpuCount, processor) {
@@ -27,7 +20,7 @@ export class UtilisationProperty extends Property {
 
         return super.parse(lines);
     }
-};
+}
 
 export class TemperatureProperty extends Property {
     constructor(gpuCount, processor) {
@@ -38,7 +31,7 @@ export class TemperatureProperty extends Property {
     setUnit(unit) {
         this._formatter.setUnit(unit);
     }
-};
+}
 
 export class MemoryProperty extends Property {
     constructor(gpuCount, processor) {
@@ -62,11 +55,11 @@ export class MemoryProperty extends Property {
 
         return values;
     }
-};
+}
 
 export class FanProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', GIcons.Icon.Fan.get(),
             new Formatter.PercentFormatter('FanFormatter'), gpuCount);
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/settingsProperties.js
+++ b/src/nvidiautil@ethanwharris/settingsProperties.js
@@ -4,14 +4,17 @@
 /* exported UtilisationProperty TemperatureProperty MemoryProperty FanProperty */
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const Formatter = Me.imports.formatter;
-const Property = Me.imports.property;
-const GIcons = Me.imports.gIcons;
+import * as Formatter from './formatter.js';
+import {Property} from './property.js';
+import * as GIcons from './gIcons.js';
+//const Formatter = Me.imports.formatter;
+//const Property = Me.imports.property;
+//const GIcons = Me.imports.gIcons;
 
-var UtilisationProperty = class extends Property.Property {
+export class UtilisationProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Utilisation', '-q GPUUtilization ', GIcons.Icon.Card.get(),
             new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
@@ -26,7 +29,7 @@ var UtilisationProperty = class extends Property.Property {
     }
 };
 
-var TemperatureProperty = class extends Property.Property {
+export class TemperatureProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Temperature', '-q [GPU]/GPUCoreTemp ', GIcons.Icon.Temp.get(),
             new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
@@ -37,7 +40,7 @@ var TemperatureProperty = class extends Property.Property {
     }
 };
 
-var MemoryProperty = class extends Property.Property {
+export class MemoryProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Memory Usage', '-q UsedDedicatedGPUMemory -q TotalDedicatedGPUMemory ', GIcons.Icon.RAM.get(),
             new Formatter.MemoryFormatter(), gpuCount);
@@ -61,7 +64,7 @@ var MemoryProperty = class extends Property.Property {
     }
 };
 
-var FanProperty = class extends Property.Property {
+export class FanProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', GIcons.Icon.Fan.get(),
             new Formatter.PercentFormatter('FanFormatter'), gpuCount);

--- a/src/nvidiautil@ethanwharris/settingsProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsProvider.js
@@ -1,22 +1,14 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported SettingsProvider */
 'use strict';
 
 import Shell from 'gi://Shell';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-//const Shell = imports.gi.Shell;
-//const Main = imports.ui.main;
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as Processor from './processor.js';
 import * as SettingsProperties from './settingsProperties.js';
 import * as Subprocess from './subprocess.js';
-//const Processor = Me.imports.processor;
-//const SettingsProperties = Me.imports.settingsProperties;
-//const Subprocess = Me.imports.subprocess;
 
 export class SettingsProvider {
     getGpuNames() {
@@ -60,4 +52,4 @@ export class SettingsProvider {
             });
         }
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/settingsProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsProvider.js
@@ -4,16 +4,21 @@
 /* exported SettingsProvider */
 'use strict';
 
-const Shell = imports.gi.Shell;
-const Main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import Shell from 'gi://Shell';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+//const Shell = imports.gi.Shell;
+//const Main = imports.ui.main;
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const Processor = Me.imports.processor;
-const SettingsProperties = Me.imports.settingsProperties;
-const Subprocess = Me.imports.subprocess;
+import * as Processor from './processor.js';
+import * as SettingsProperties from './settingsProperties.js';
+import * as Subprocess from './subprocess.js';
+//const Processor = Me.imports.processor;
+//const SettingsProperties = Me.imports.settingsProperties;
+//const Subprocess = Me.imports.subprocess;
 
-var SettingsProvider = class {
+export class SettingsProvider {
     getGpuNames() {
         return Subprocess.execCommunicate(['nvidia-settings', '-q', 'GpuUUID', '-t'])
       .then(output => output.split('\n').map((gpu, index) => `GPU ${index}`));

--- a/src/nvidiautil@ethanwharris/smiProperties.js
+++ b/src/nvidiautil@ethanwharris/smiProperties.js
@@ -1,32 +1,25 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported UtilisationProperty PowerProperty TemperatureProperty MemoryProperty FanProperty */
 'use strict';
-
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as Formatter from './formatter.js';
 import {Property} from './property.js';
 import * as GIcons from './gIcons.js';
-//const Property = Me.imports.property;
-//const Formatter = Me.imports.formatter;
-//const GIcons = Me.imports.gIcons;
 
 export class UtilisationProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Utilisation', 'utilization.gpu,', GIcons.Icon.Card.get(),
             new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
     }
-};
+}
 
 export class PowerProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Power Usage (W)', 'power.draw,', GIcons.Icon.Power.get(),
             new Formatter.PowerFormatter(), gpuCount);
     }
-};
+}
 
 export class TemperatureProperty extends Property {
     constructor(gpuCount, processor) {
@@ -37,7 +30,7 @@ export class TemperatureProperty extends Property {
     setUnit(unit) {
         this._formatter.setUnit(unit);
     }
-};
+}
 
 export class MemoryProperty extends Property {
     constructor(gpuCount, processor) {
@@ -61,11 +54,11 @@ export class MemoryProperty extends Property {
 
         return values;
     }
-};
+}
 
 export class FanProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Fan Speed', 'fan.speed,', GIcons.Icon.Fan.get(),
             new Formatter.PercentFormatter('FanFormatter'), gpuCount);
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/smiProperties.js
+++ b/src/nvidiautil@ethanwharris/smiProperties.js
@@ -4,28 +4,31 @@
 /* exported UtilisationProperty PowerProperty TemperatureProperty MemoryProperty FanProperty */
 'use strict';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const Property = Me.imports.property;
-const Formatter = Me.imports.formatter;
-const GIcons = Me.imports.gIcons;
+import * as Formatter from './formatter.js';
+import {Property} from './property.js';
+import * as GIcons from './gIcons.js';
+//const Property = Me.imports.property;
+//const Formatter = Me.imports.formatter;
+//const GIcons = Me.imports.gIcons;
 
-var UtilisationProperty = class extends Property.Property {
+export class UtilisationProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Utilisation', 'utilization.gpu,', GIcons.Icon.Card.get(),
             new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
     }
 };
 
-var PowerProperty = class extends Property.Property {
+export class PowerProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Power Usage (W)', 'power.draw,', GIcons.Icon.Power.get(),
             new Formatter.PowerFormatter(), gpuCount);
     }
 };
 
-var TemperatureProperty = class extends Property.Property {
+export class TemperatureProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Temperature', 'temperature.gpu,', GIcons.Icon.Temp.get(),
             new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
@@ -36,7 +39,7 @@ var TemperatureProperty = class extends Property.Property {
     }
 };
 
-var MemoryProperty = class extends Property.Property {
+export class MemoryProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Memory Usage', 'memory.used,memory.total,', GIcons.Icon.RAM.get(),
             new Formatter.MemoryFormatter('MemoryFormatter'), gpuCount);
@@ -60,7 +63,7 @@ var MemoryProperty = class extends Property.Property {
     }
 };
 
-var FanProperty = class extends Property.Property {
+export class FanProperty extends Property {
     constructor(gpuCount, processor) {
         super(processor, 'Fan Speed', 'fan.speed,', GIcons.Icon.Fan.get(),
             new Formatter.PercentFormatter('FanFormatter'), gpuCount);

--- a/src/nvidiautil@ethanwharris/smiProvider.js
+++ b/src/nvidiautil@ethanwharris/smiProvider.js
@@ -1,20 +1,13 @@
 /* SPDX-License-Identifier: GPL-3.0-or-later */
 /* SPDX-FileCopyrightText: Contributors to the gnome-nvidia-extension project. */
 
-/* exported SmiProvider */
 'use strict';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-//const Main = imports.ui.main;
-//const ExtensionUtils = imports.misc.extensionUtils;
-//const Me = ExtensionUtils.getCurrentExtension();
 
 import * as Processor from './processor.js';
 import * as SmiProperties from './smiProperties.js';
 import * as Subprocess from './subprocess.js';
-//const Processor = Me.imports.processor;
-//const SmiProperties = Me.imports.smiProperties;
-//const Subprocess = Me.imports.subprocess;
 
 export class SmiProvider {
     getGpuNames() {
@@ -44,4 +37,4 @@ export class SmiProvider {
     openSettings() {
         Main.notifyError('Settings are not available in smi mode', 'Switch to a provider which supports nivida-settings');
     }
-};
+}

--- a/src/nvidiautil@ethanwharris/smiProvider.js
+++ b/src/nvidiautil@ethanwharris/smiProvider.js
@@ -4,15 +4,19 @@
 /* exported SmiProvider */
 'use strict';
 
-const Main = imports.ui.main;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+//const Main = imports.ui.main;
+//const ExtensionUtils = imports.misc.extensionUtils;
+//const Me = ExtensionUtils.getCurrentExtension();
 
-const Processor = Me.imports.processor;
-const SmiProperties = Me.imports.smiProperties;
-const Subprocess = Me.imports.subprocess;
+import * as Processor from './processor.js';
+import * as SmiProperties from './smiProperties.js';
+import * as Subprocess from './subprocess.js';
+//const Processor = Me.imports.processor;
+//const SmiProperties = Me.imports.smiProperties;
+//const Subprocess = Me.imports.subprocess;
 
-var SmiProvider = class {
+export class SmiProvider {
     getGpuNames() {
         return Subprocess.execCommunicate(['nvidia-smi', '--query-gpu=gpu_name', '--format=csv,noheader'])
       .then(output => output.split('\n').map((gpu, index) => `${index}: ${gpu}`));

--- a/src/nvidiautil@ethanwharris/subprocess.js
+++ b/src/nvidiautil@ethanwharris/subprocess.js
@@ -5,7 +5,9 @@
 /* eslint-disable require-await */
 'use strict';
 
-const {Gio, GLib} = imports.gi;
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+//const {Gio, GLib} = imports.gi;
 
 /**
  * Execute a command asynchronously and check the exit status.
@@ -16,7 +18,7 @@ const {Gio, GLib} = imports.gi;
  * @param {Gio.Cancellable} [cancellable] - optional cancellable object
  * @returns {Promise<boolean>} - The process success
  */
-async function execCheck(argv, cancellable = null) {
+export async function execCheck(argv, cancellable = null) {
     let cancelId = 0;
     let proc = new Gio.Subprocess({
         argv,
@@ -64,7 +66,7 @@ async function execCheck(argv, cancellable = null) {
  * @param {Gio.Cancellable} [cancellable] - optional cancellable object
  * @returns {Promise<string>} - The process output
  */
-async function execCommunicate(argv, input = null, cancellable = null) {
+export async function execCommunicate(argv, input = null, cancellable = null) {
     let cancelId = 0;
     let flags = Gio.SubprocessFlags.STDOUT_PIPE |
         Gio.SubprocessFlags.STDERR_PIPE;

--- a/src/nvidiautil@ethanwharris/subprocess.js
+++ b/src/nvidiautil@ethanwharris/subprocess.js
@@ -1,13 +1,11 @@
 /* SPDX-License-Identifier: MIT */
 /* SPDX-FileCopyrightText: 2021 Evan Welsh */
 
-/* exported execCommunicate execCheck */
 /* eslint-disable require-await */
 'use strict';
 
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
-//const {Gio, GLib} = imports.gi;
 
 /**
  * Execute a command asynchronously and check the exit status.


### PR DESCRIPTION
This PR contains the changes to imports required for Gnome 45. Since **it breaks backwards compatibility**, I created a new "legacy" branch from master before this PR that contains the old code compatible with versions 40-44.

I tried to keep the changes minimal, but it was still necessary to change every JS file, since all imports had to be updated.
This addresses issue #212.