### PR TITLE
Better wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Restart gnome shell by logging out and back in.
 On X11, you can also use `alt + f2`, `r`, `Enter` to reload more quickly.
 Afterwards, you can enable the extension in the gnome tweak tool.
 
+# Selecting Properties
+By default, no measurements are displayed in the menu bar.
+You can open the dropdown menu and select the properties to be shown.
+
 # Icons
 For icons we use font-awesome:
 http://fontawesome.io/

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ Additionally, `nvidia-settings` is supported as a data source.
     make
     make install
 
-Restart gnome shell by logging out and back in.
-On X11, you can also use `alt + f2`, `r`, `Enter` to reload more quickly.
-Afterwards, you can enable the extension in the gnome tweak tool.
+Restart gnome shell to load the extension:
+- On Wayland, log out and back in.
+- On X11, you can also use `alt + f2`, `r`, `Enter` to reload more quickly.
+
+Afterwards, you can enable the extension in gnome-extensions.
 
 ## Selecting Properties
 By default, no measurements are displayed in the menu bar.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ For older shell versions, please check out the "legacy" branch.
 The extension requires `nvidia-smi`, which should be included with the drivers.
 Additionally, `nvidia-settings` is supported as a data source.
 
+If you still use [Bumblebee](https://wiki.archlinux.org/title/Bumblebee), the data can also be sourced through `optirun` (this is untested and may be deprecated in future versions).
+
 ## Installation from git
     git clone https://github.com/ethanwharris/gnome-nvidia-extension.git
     cd gnome-nvidia-extension

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 A Gnome extension to show Nvidia GPU information
 (https://extensions.gnome.org/extension/1320/nvidia-gpu-stats-tool/)
 
-# Supported Gnome versions
+## Supported Gnome versions
 The "master" branch supports only Gnome v45+.
 For older shell versions, please check out the "legacy" branch.
 
-# Requirements
+## Requirements
 The extension requires `nvidia-smi`, which should be included with the drivers.
 Additionally, `nvidia-settings` is supported as a data source.
 
-# Installation from git
+## Installation from git
     git clone https://github.com/ethanwharris/gnome-nvidia-extension.git
     cd gnome-nvidia-extension
     make
@@ -23,11 +23,11 @@ Restart gnome shell by logging out and back in.
 On X11, you can also use `alt + f2`, `r`, `Enter` to reload more quickly.
 Afterwards, you can enable the extension in the gnome tweak tool.
 
-# Selecting Properties
+## Selecting Properties
 By default, no measurements are displayed in the menu bar.
 You can open the dropdown menu and select the properties to be shown.
 
-# Icons
+## Icons
 For icons we use font-awesome:
 http://fontawesome.io/
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ The "master" branch supports only Gnome v45+.
 For older shell versions, please check out the "legacy" branch.
 
 # Requirements
-nvidia-settings and nvidia-smi
+The extension requires `nvidia-smi`, which should be included with the drivers.
+Additionally, `nvidia-settings` is supported as a data source.
 
 # Installation from git
     git clone https://github.com/ethanwharris/gnome-nvidia-extension.git
@@ -18,8 +19,9 @@ nvidia-settings and nvidia-smi
     make
     make install
 
-Use `alt + f2`, `r`, `Enter` to restart the gnome shell (if this is not allowed then log out and log back in)
-Enable the extension in the gnome tweak tool.
+Restart gnome shell by logging out and back in.
+On X11, you can also use `alt + f2`, `r`, `Enter` to reload more quickly.
+Afterwards, you can enable the extension in the gnome tweak tool.
 
 # Icons
 For icons we use font-awesome:

--- a/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
@@ -20,18 +20,11 @@ export class SettingsAndSmiProvider {
     }
 
     getProperties(gpuCount) {
-        this.storedProperties = [
-            new SettingsProperties.UtilisationProperty(gpuCount, Processor.NVIDIA_SETTINGS),
-            new SettingsProperties.TemperatureProperty(gpuCount, Processor.NVIDIA_SETTINGS),
-            new SettingsProperties.MemoryProperty(gpuCount, Processor.NVIDIA_SETTINGS),
-            new SettingsProperties.FanProperty(gpuCount, Processor.NVIDIA_SETTINGS),
-            new SmiProperties.PowerProperty(gpuCount, Processor.NVIDIA_SMI),
-        ];
-        return this.storedProperties;
+        return this.smi.getProperties(gpuCount);
     }
 
     retrieveProperties() {
-        return this.storedProperties;
+        return this.smi.retrieveProperties();
     }
 
     hasSettings() {


### PR DESCRIPTION
This small PR addresses wayland usability issues. It changes the (default) SettingsAndSmiProvider to source all measurements from nvidia-smi, which should remove error messages popping up non-stop in case nvidia-settings is not installed.
Furthermore, I improved the readme to clarify how to restart the shell and how to select the properties to be displayed in the menu bar.

closes #210 #208 #202