### PR TITLE
Gnome46

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -2,16 +2,21 @@
 # SPDX-FileCopyrightText: 2019 haya14busa
 
 name: reviewdog
+
 on: [pull_request]
+
+env:
+  ESLINT_USE_FLAT_CONFIG: false
+
 jobs:
   eslint:
     name: runner / eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
       - run: npm install eslint eslint-plugin-jsdoc -D
       - uses: reviewdog/action-eslint@v1
         with:

--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -54,7 +54,7 @@ class PropertyMenuItem extends PopupMenu.PopupBaseMenuItem {
         this._box = box;
         this.labelManager = labelManager;
 
-        this.actor.add(new St.Icon({style_class: 'popup-menu-icon', gicon: property.getIcon(), icon_size: 16}));
+        this.actor.add_child(new St.Icon({style_class: 'popup-menu-icon', gicon: property.getIcon(), icon_size: 16}));
 
         this.label = new St.Label({text: property.getName()});
         this.actor.add_child(this.label);
@@ -73,7 +73,7 @@ class PropertyMenuItem extends PopupMenu.PopupBaseMenuItem {
         this._box.add_child(this._icon);
         this._box.add_child(this._statisticLabelVisible);
 
-        this.actor.add(this._statisticLabelHidden);
+        this.actor.add_child(this._statisticLabelHidden);
         this._visible = false;
         this._box.visible = false;
 
@@ -230,8 +230,8 @@ class MainMenu extends PanelMenu.Button {
 
         this.properties = new St.BoxLayout({style_class: 'panel-status-menu-box'});
 
-        hbox.add_actor(this.properties);
-        hbox.add_actor(PopupMenu.arrowIcon(St.Side.BOTTOM));
+        hbox.add_child(this.properties);
+        hbox.add_child(PopupMenu.arrowIcon(St.Side.BOTTOM));
         this.add_child(hbox);
 
         this._reload();
@@ -397,7 +397,7 @@ class MainMenu extends PanelMenu.Button {
     }
 
     _updatePanelPosition() {
-        this.container.get_parent().remove_actor(this.container);
+        this.container.get_parent().remove_child(this.container);
 
         let boxes = {
             left: Main.panel._leftBox,

--- a/src/nvidiautil@ethanwharris/metadata.json
+++ b/src/nvidiautil@ethanwharris/metadata.json
@@ -2,7 +2,8 @@
   "description":
     "Shows NVIDIA GPU stats in the toolbar. Requires nvidia-settings or nvidia-smi. Includes Bumblebee support.",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "name": "NVIDIA GPU Stats Tool",
   "settings-schema": "org.gnome.shell.extensions.nvidiautil",

--- a/src/nvidiautil@ethanwharris/prefs.js
+++ b/src/nvidiautil@ethanwharris/prefs.js
@@ -71,7 +71,6 @@ export default class NvidiaUtilPreferences extends ExtensionPreferences {
 
 /**
  * Construct the individual widget for an individual setting
- *
  * @param {string} setting Key from the SETTINGS dictionary
  * @returns {object} GTK box for this single setting
  */
@@ -152,7 +151,6 @@ function buildSettingWidget(setting) {
 
 /**
  * Construct the entire widget for the settings dialog
- *
  * @returns {object} GTK box containing the entire settings dialog
  */
 function buildPrefsWidget() {

--- a/src/nvidiautil@ethanwharris/processor.js
+++ b/src/nvidiautil@ethanwharris/processor.js
@@ -13,7 +13,6 @@ export const OPTIMUS = 2;
 
 /**
  * Utility function to perform one function and then another
- *
  * @param {Function} first The function executed first
  * @param {Function} second The function executed second
  * @returns {Function} A function that runs both given functions

--- a/src/nvidiautil@ethanwharris/subprocess.js
+++ b/src/nvidiautil@ethanwharris/subprocess.js
@@ -11,7 +11,6 @@ import GLib from 'gi://GLib';
  * Execute a command asynchronously and check the exit status.
  *
  * If given, @cancellable can be used to stop the process before it finishes.
- *
  * @param {string[]} argv - a list of string arguments
  * @param {Gio.Cancellable} [cancellable] - optional cancellable object
  * @returns {Promise<boolean>} - The process success
@@ -58,7 +57,6 @@ export async function execCheck(argv, cancellable = null) {
  *
  * If given, @input will be passed to `stdin` and @cancellable can be used to
  * stop the process before it finishes.
- *
  * @param {string[]} argv - a list of string arguments
  * @param {string} [input] - Input to write to `stdin` or %null to ignore
  * @param {Gio.Cancellable} [cancellable] - optional cancellable object


### PR DESCRIPTION
This continues the work of #213 for gnome 46. Thankfully, this time around, the delta is fairly minimal and should be fully backwards compatible. But boy oh boy, I sure hate the debugging experience in gnome-shell.

The necessary change is outlined here in the documentation: https://gjs.guide/extensions/upgrading/gnome-shell-46.html#gjs

_Note: This is especially interesting with Ubuntu 24.04 just around the corner. If we manage to finally release this update, people could actually use the extension from day one :)_