### PR TITLE
fix review concerns

### DIFF
--- a/src/nvidiautil@ethanwharris/extension.js
+++ b/src/nvidiautil@ethanwharris/extension.js
@@ -350,8 +350,8 @@ class MainMenu extends PanelMenu.Button {
             accessible_name: 'Open Preferences',
             style_class: 'button',
             child: new St.Icon({
-                icon_name: GIcons.Icon.Wrench.name,
-                gicon: GIcons.Icon.Wrench.get(),
+                icon_name: GIcons.Icon.Wrench,
+                gicon: GIcons.get(GIcons.Icon.Wrench),
             }),
         });
         this.wrench.connect('clicked', () => {
@@ -368,8 +368,8 @@ class MainMenu extends PanelMenu.Button {
                 accessible_name: 'Open Nvidia Settings',
                 style_class: 'button',
                 child: new St.Icon({
-                    icon_name: GIcons.Icon.Cog.name,
-                    gicon: GIcons.Icon.Cog.get(),
+                    icon_name: GIcons.Icon.Cog,
+                    gicon: GIcons.get(GIcons.Icon.Cog),
                 }),
             });
             this.cog.connect('clicked', () => this.provider.openSettings());

--- a/src/nvidiautil@ethanwharris/gIcons.js
+++ b/src/nvidiautil@ethanwharris/gIcons.js
@@ -6,21 +6,22 @@
 import Gio from 'gi://Gio';
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 
-export class Icon {
-    static Card = new this('card-symbolic');
-    static Temp = new this('temp-symbolic');
-    static RAM = new this('ram-symbolic');
-    static Fan = new this('fan-symbolic');
-    static Power = new this('power-symbolic');
-    static Wrench = new this('wrench-symbolic');
-    static Cog = new this('cog-symbolic');
+export const Icon = {
+    Card: 'card-symbolic',
+    Temp: 'temp-symbolic',
+    RAM: 'ram-symbolic',
+    Fan: 'fan-symbolic',
+    Power: 'power-symbolic',
+    Wrench: 'wrench-symbolic',
+    Cog: 'cog-symbolic',
+};
 
-    constructor(name) {
-        this.name = name;
-    }
-
-    get() {
-        let extensionObject = Extension.lookupByURL(import.meta.url);
-        return Gio.icon_new_for_string(`${extensionObject.path}/icons/${this.name}.svg`);
-    }
+/**
+ * get an icon from the extension directory
+ * @param {string} name file name of the icon
+ * @returns {Gio.Icon} new gicon
+ */
+export function get(name) {
+    let extensionObject = Extension.lookupByURL(import.meta.url);
+    return Gio.icon_new_for_string(`${extensionObject.path}/icons/${name}.svg`);
 }

--- a/src/nvidiautil@ethanwharris/metadata.json
+++ b/src/nvidiautil@ethanwharris/metadata.json
@@ -9,5 +9,5 @@
   "settings-schema": "org.gnome.shell.extensions.nvidiautil",
   "uuid": "nvidiautil@ethanwharris",
   "url": "https://github.com/ethanwharris/gnome-nvidia-extension",
-  "version": 11
+  "version": 14
 }

--- a/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
+++ b/src/nvidiautil@ethanwharris/settingsAndSmiProvider.js
@@ -3,9 +3,6 @@
 
 'use strict';
 
-import * as SettingsProperties from './settingsProperties.js';
-import * as SmiProperties from './smiProperties.js';
-import * as Processor from './processor.js';
 import * as SettingsProvider from './settingsProvider.js';
 import * as SmiProvider from './smiProvider.js';
 

--- a/src/nvidiautil@ethanwharris/settingsProperties.js
+++ b/src/nvidiautil@ethanwharris/settingsProperties.js
@@ -9,7 +9,7 @@ import * as GIcons from './gIcons.js';
 
 export class UtilisationProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Utilisation', '-q GPUUtilization ', GIcons.Icon.Card.get(),
+        super(processor, 'Utilisation', '-q GPUUtilization ', GIcons.get(GIcons.Icon.Card),
             new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
     }
 
@@ -24,7 +24,7 @@ export class UtilisationProperty extends Property {
 
 export class TemperatureProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Temperature', '-q [GPU]/GPUCoreTemp ', GIcons.Icon.Temp.get(),
+        super(processor, 'Temperature', '-q [GPU]/GPUCoreTemp ', GIcons.get(GIcons.Icon.Temp),
             new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
     }
 
@@ -35,7 +35,7 @@ export class TemperatureProperty extends Property {
 
 export class MemoryProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Memory Usage', '-q UsedDedicatedGPUMemory -q TotalDedicatedGPUMemory ', GIcons.Icon.RAM.get(),
+        super(processor, 'Memory Usage', '-q UsedDedicatedGPUMemory -q TotalDedicatedGPUMemory ', GIcons.get(GIcons.Icon.RAM),
             new Formatter.MemoryFormatter(), gpuCount);
     }
 
@@ -59,7 +59,7 @@ export class MemoryProperty extends Property {
 
 export class FanProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', GIcons.Icon.Fan.get(),
+        super(processor, 'Fan Speed', '-q GPUCurrentFanSpeed ', GIcons.get(GIcons.Icon.Fan),
             new Formatter.PercentFormatter('FanFormatter'), gpuCount);
     }
 }

--- a/src/nvidiautil@ethanwharris/smiProperties.js
+++ b/src/nvidiautil@ethanwharris/smiProperties.js
@@ -9,21 +9,21 @@ import * as GIcons from './gIcons.js';
 
 export class UtilisationProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Utilisation', 'utilization.gpu,', GIcons.Icon.Card.get(),
+        super(processor, 'Utilisation', 'utilization.gpu,', GIcons.get(GIcons.Icon.Card),
             new Formatter.PercentFormatter('UtilisationFormatter'), gpuCount);
     }
 }
 
 export class PowerProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Power Usage (W)', 'power.draw,', GIcons.Icon.Power.get(),
+        super(processor, 'Power Usage (W)', 'power.draw,', GIcons.get(GIcons.Icon.Power),
             new Formatter.PowerFormatter(), gpuCount);
     }
 }
 
 export class TemperatureProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Temperature', 'temperature.gpu,', GIcons.Icon.Temp.get(),
+        super(processor, 'Temperature', 'temperature.gpu,', GIcons.get(GIcons.Icon.Temp),
             new Formatter.TempFormatter(Formatter.CENTIGRADE), gpuCount);
     }
 
@@ -34,7 +34,7 @@ export class TemperatureProperty extends Property {
 
 export class MemoryProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Memory Usage', 'memory.used,memory.total,', GIcons.Icon.RAM.get(),
+        super(processor, 'Memory Usage', 'memory.used,memory.total,', GIcons.get(GIcons.Icon.RAM),
             new Formatter.MemoryFormatter('MemoryFormatter'), gpuCount);
     }
 
@@ -58,7 +58,7 @@ export class MemoryProperty extends Property {
 
 export class FanProperty extends Property {
     constructor(gpuCount, processor) {
-        super(processor, 'Fan Speed', 'fan.speed,', GIcons.Icon.Fan.get(),
+        super(processor, 'Fan Speed', 'fan.speed,', GIcons.get(GIcons.Icon.Fan),
             new Formatter.PercentFormatter('FanFormatter'), gpuCount);
     }
 }


### PR DESCRIPTION
This PR addresses the review issue mentioned in #212. I don't really get why this is a problem now and wasn't before, that code hasn't changed. Anyway:
> Rejected because static is the same as global scope (line 10-16 `gIcons.js`).

Instead of static class members that contain Icon objects, we now have a poor man's enum that contains the icon names and a getter to fetch the icon.
> Recommendation: `lookupByURL()` is a bad practice.

I decided not to address this, since we would have to pass the extensionObject through the whole class hierarchy.