### PR TITLE
version bump in metadata.json

### DIFF
--- a/src/nvidiautil@ethanwharris/metadata.json
+++ b/src/nvidiautil@ethanwharris/metadata.json
@@ -3,7 +3,8 @@
     "Shows NVIDIA GPU stats in the toolbar. Requires nvidia-settings or nvidia-smi. Includes Bumblebee support.",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "name": "NVIDIA GPU Stats Tool",
   "settings-schema": "org.gnome.shell.extensions.nvidiautil",


### PR DESCRIPTION
This PR bumps the supported gnome version to 47. Since we still haven't released the update, we could include this one as well.